### PR TITLE
Fixed category in check_argument function

### DIFF
--- a/modules/signatures/antidbg_windows.py
+++ b/modules/signatures/antidbg_windows.py
@@ -26,7 +26,13 @@ class AntiDBGWindows(Signature):
     def run(self):
         indicators = [
             "OLLYDBG",
-            "WinDbgFrameClass"
+            "WinDbgFrameClass",
+            "pediy06",
+            "GBDYLLO",
+            "FilemonClass",
+            "PROCMON_WINDOW_CLASS",
+            "File Monitor - Sysinternals: www.sysinternals.com",
+            "Process Monitor - Sysinternals: www.sysinternals.com",
         ]
 
         for indicator in indicators:


### PR DESCRIPTION
{
"category": "windows", 
"status": false, 
"return": "0x00000000", 
"timestamp": "2013-05-15 21:36:32,491", 
"thread_id": "1400", 
"repeated": 0, 
"api": "FindWindowA", 
"arguments": [
 {
   "name": "ClassName", 
   "value": "OLLYDBG"
 }, 
 {
   "name": "WindowName", 
   "value": ""
 }
]
}
