### PR TITLE
prevents FA on path with "forward slash"

### DIFF
--- a/modules/signatures/persistence_ads.py
+++ b/modules/signatures/persistence_ads.py
@@ -24,12 +24,13 @@ class ADS(Signature):
     minimum = "0.5"
 
     def run(self):
+        result = False
         for file_path in self.results["behavior"]["summary"]["files"]:
             if len(file_path) <= 3:
                 continue
 
-            if ":" in file_path.split("\\")[-1]:
+            if ":" in file_path.replace("/", "\\").split("\\")[-1]:
                 self.data.append({"file" : file_path})
-                return True
+                result = True
 
-        return False
+        return result


### PR DESCRIPTION
Modified to prevent detection on file_path containing "forward slash" e.g. "c:/documen~1".
This will also list all the files with ADS before returning the result.
