### PR TITLE
Update banker_spyeye_mutex.py

### DIFF
--- a/modules/signatures/banker_spyeye_mutex.py
+++ b/modules/signatures/banker_spyeye_mutex.py
@@ -26,7 +26,7 @@ class SpyEyeMutexes(Signature):
 
     def run(self):
         indicators = [
-            "zXeRY3a_PtW.*",
+            ".*zXeRY3a_PtW.*",          ## https://malwr.com/analysis/ZmMzNTk0YWU5OGM4NDUzNjg2YmEzYjcxNTFjNTBkM2I/
             "SPYNET",
             "__CLEANSWEEP__",
             "__CLEANSWEEP_UNINSTALL__",


### PR DESCRIPTION
The mutex as seen at https://malwr.com/analysis/ZmMzNTk0YWU5OGM4NDUzNjg2YmEzYjcxNTFjNTBkM2I/ is "C:\zXeRY3a_PtW|00000000" and didn’t matched the original signature because of additional "C:\" at the start.
