### PR TITLE
Signature to detect document files creating network traffic

### DIFF
--- a/modules/signatures/network/network_docfile.py
+++ b/modules/signatures/network/network_docfile.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2016 Kevin Ross. Also uses code from Will Metcalf
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class NetworkDocumentFile(Signature):
+    name = "network_document_file"
+    description = "A document file initiated network communications indicative of a potential exploit or payload download"
+    severity = 3
+    categories = ["exploit", "downloader"]
+    authors = ["Kevin Ross", "Will Metcalf"]
+    minimum = "2.0"
+
+    proc_list =["wordview.exe","winword.exe","excel.exe","powerpnt.exe","outlook.exe","acrord32.exe","acrord64.exe"]
+
+    filter_apinames = set(["InternetCrackUrlW","InternetCrackUrlA","URLDownloadToFileW","HttpOpenRequestW","InternetReadFile","WSASend"])
+    filter_analysistypes = set(["file"])
+
+    def on_call(self, call, process):
+        pname = process["process_name"].lower()
+        if pname in self.proc_list:
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()

--- a/modules/signatures/network/network_docfile.py
+++ b/modules/signatures/network/network_docfile.py
@@ -25,7 +25,7 @@ class NetworkDocumentFile(Signature):
 
     proc_list =["wordview.exe","winword.exe","excel.exe","powerpnt.exe","outlook.exe","acrord32.exe","acrord64.exe"]
 
-    filter_apinames = set(["InternetCrackUrlW","InternetCrackUrlA","URLDownloadToFileW","HttpOpenRequestW","InternetReadFile","WSASend"])
+    filter_apinames = set(["InternetCrackUrlW","InternetCrackUrlA","URLDownloadToFileW","HttpOpenRequestW","InternetReadFile","WSASend","connect"])
     filter_analysistypes = set(["file"])
 
     def on_call(self, call, process):

--- a/modules/signatures/network/network_docfile.py
+++ b/modules/signatures/network/network_docfile.py
@@ -25,7 +25,7 @@ class NetworkDocumentFile(Signature):
 
     proc_list =["wordview.exe","winword.exe","excel.exe","powerpnt.exe","outlook.exe","acrord32.exe","acrord64.exe"]
 
-    filter_apinames = set(["InternetCrackUrlW","InternetCrackUrlA","URLDownloadToFileW","HttpOpenRequestW","InternetReadFile","WSASend","connect"])
+    filter_apinames = set(["InternetCrackUrlW","InternetCrackUrlA","URLDownloadToFileW","HttpOpenRequestW","InternetReadFile","WSASend"])
     filter_analysistypes = set(["file"])
 
     def on_call(self, call, process):


### PR DESCRIPTION
This is my first conversion sig to 2.0 so please check although it appears to work fine and is the start of me trying to convert some of the signatures from cuckoo-modified over into cuckoo-2.0 so at least a start has been made. The signature is to convert the ideas from this signature:
https://raw.githubusercontent.com/spender-sandbox/community-modified/master/modules/signatures/network_docfile_http.py

If the above link can be used to verifiy the logic of this signature before commit then that would be best given this is my first cuckoo 2.0 signature and also my pythons skills are fine but needs an expert eye :-) I intend to start the conversion process as I can because as previously discussed in general there is a lot of excellent signatures and while I may not manage everything at least it helps out with what I can.