### PR TITLE
Add in sig for ransomware appending new extension

### DIFF
--- a/modules/signatures/windows/ransomware_appendsextensions.py
+++ b/modules/signatures/windows/ransomware_appendsextensions.py
@@ -33,7 +33,7 @@ class RamsomwareAppendsExtension(Signature):
     def on_call(self, call, process):
         origfile = call["arguments"]["oldfilepath"]
         newfile = call["arguments"]["newfilepath"]
-        if origfile != newfile:
+        if origfile != newfile and not oldfilepath.endswith(".tmp") and not newfile.endswith(".tmp"):
             origextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", origfile)
             if not origextextract:
                 return None
@@ -45,16 +45,17 @@ class RamsomwareAppendsExtension(Signature):
                 self.mark_call()
 
     def on_complete(self):
-        if self.has_marks(500):
+        if self.has_marks(1000):
             self.description = self.description % 500
             self.severity = 6
+        if self.has_marks(600):
+            self.description = self.description % 500
+            self.severity = 5
         elif self.has_marks(100):
             self.description = self.description % 100
-            self.severity = 5
+            self.severity = 4
         elif self.has_marks(50):
             self.description = self.description % 50
-            self.severity = 4
-        else:
-            self.description = self.description % 5
+            self.severity = 3
 
-        return self.has_marks(5)
+        return self.has_marks(50)

--- a/modules/signatures/windows/ransomware_appendsextensions.py
+++ b/modules/signatures/windows/ransomware_appendsextensions.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+try:
+    import re2 as re
+except ImportError:
+    import re
+
+class RamsomwareAppendsExtension(Signature):
+    name = "ransomware_file_moves"
+    description = "Appends a new file extension to more than %d files indicative of a ransomware file encryption process"
+    severity = 3
+    families = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    filter_apinames = "MoveFileWithProgressW", "MoveFileWithProgressTransactedW"
+
+    def on_call(self, call, process):
+        origfile = call["arguments"]["oldfilepath"]
+        newfile = call["arguments"]["newfilepath"]
+        if origfile != newfile:
+            origextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", origfile)
+            if not origextextract:
+                return None
+            newextextract = re.search("^.*(\.[a-zA-Z0-9_\-]{1,}$)", newfile)
+            if not newextextract:
+                return None
+            newextension = newextextract.group(1)
+            if newextension != ".tmp":
+                self.mark_call()
+
+    def on_complete(self):
+        if self.has_marks(500):
+            self.description = self.description % 500
+            self.severity = 6
+        elif self.has_marks(100):
+            self.description = self.description % 100
+            self.severity = 5
+        elif self.has_marks(50):
+            self.description = self.description % 50
+            self.severity = 4
+        else:
+            self.description = self.description % 5
+
+        return self.has_marks(5)


### PR DESCRIPTION
This signature is based off one of 3 aspects which makes up the following signature: https://raw.githubusercontent.com/spender-sandbox/community-modified/master/modules/signatures/ransomware_filemodifications.py

1) Multiple file moves (already covered in cuckoo 2.0 with modifies_files but some minor changes coming)
2) Appending new extensions to multiple files (curently only covered by file_move ransomware method). This is what this sig covers.
3) Dropping lots of unknown file types (still to look at) - i.e TelsaCrypt is now detected by this where as a few months ago it used file move method.

Based on these 3 things I found the original cuckoo-modified signature was capable of detecting most ransomware file modifications techniques in a generic way so they are worth doing. Originally as you can see in the original this was all in one sig and you can see an example of the signature shown in this blog post https://www.proofpoint.com/uk/threat-insight/post/cryptxxx-new-ransomware-actors-behind-reveton-dropping-angler