### PR TITLE
Remove FP in dexter sig (FPs in office and legit files)

### DIFF
--- a/modules/signatures/windows/pos_dexter.py
+++ b/modules/signatures/windows/pos_dexter.py
@@ -14,19 +14,11 @@ class Dexter(Signature):
     authors = ["RedSocks"]
     minimum = "2.0"
 
-    regkeys_re = [
-        ".*\\\\SOFTWARE\\\\MICROSOFT\\\\WINDOWS\\\\CURRENTVERSION\\\\POLICIES\\\\ASSOCIATIONS",
-    ]
-
     mutexes_re = [
         ".*WindowsResilienceServiceMutex",
     ]
 
     def on_complete(self):
-        for indicator in self.regkeys_re:
-            match = self.check_key(pattern=indicator, regex=True)
-            if match:
-                self.mark_ioc("regkey", match)
 
         for indicator in self.mutexes_re:
             match = self.check_mutex(pattern=indicator)


### PR DESCRIPTION
This is to remove the key  HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Associations. This appears across a lot of malware & legit files to and is not a strong indicator.

To be honest though I am wondering if it is possible to move these signatures to a seperate low fidelity section apart from main signature set. This is not meant as a negative stab at the signatures themselves - they have their place in research analysis - it is because I think:

- In my analysis now using cuckoo-2.0 these signatures trigger either FPs or alerts on completely unrelated malware samples
- They are using static indicators  which are easily changed
- Some appear to be using dated IOCs that are also easy to evade and so are no longer relevant even within the same malware family tree
- A signature more behaviour based would be harder to evade & more reliable that static indicators or even what appear an IOC linked to a specific sample group at a point in time. 
- FPs may cause mis-identifification of a sample (i.e TeslaCryypt, Maktub and some other programs are detected by this sig as Dexter).
- Fixing these family signatures to be accurate given their volume would be time consuming in the main signature set. 

It is true though that some samples may be completely 100% true positive detected by some of these. The thing is there is so many it may be hard to determine.

An example would be this:
cuckoo 2: https://github.com/cuckoosandbox/community/blob/master/modules/signatures/windows/vir_dyreza.py
cuckoo-modified: https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/dyre_apis.py

Another excellent example is this Locky sig showing the wide yet more precise net cast: https://raw.githubusercontent.com/spender-sandbox/community-modified/master/modules/signatures/locky_apis.py

I hope this doesn't start of a negative discussion but a positive one in the improvement of the signatures to describe malicious behaviours.