### PR TITLE
Create another ransomware file modification detection

### DIFF
--- a/modules/signatures/windows/ransomware_droppedfiles.py
+++ b/modules/signatures/windows/ransomware_droppedfiles.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class RamsomwareDroppedFiles(Signature):
+    name = "ransomware_dropped_files"
+    description = "Drops many unknown file mime types indicative of ransomware writing encrypted files back to disk"
+    severity = 3
+    families = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        droppedcount = 0
+
+        for dropped in self.get_results("dropped", []):
+            droppedtype = dropped["type"]
+            droppedname = dropped["name"]
+            if droppedtype == "data" and ".tmp" not in droppedname:
+                droppedcount += 1
+        if droppedcount > 50:
+            if droppedcount > 1000:
+                self.severity = 6
+            elif droppedcount > 500:
+                self.severity = 5
+            elif droppedcount > 200:
+                self.severity = 4
+            return True


### PR DESCRIPTION
This is based on large numbers of unknown files being dropped to disk. It is based on this https://raw.githubusercontent.com/spender-sandbox/community-modified/master/modules/signatures/ransomware_filemodifications.py; specifically this bit:

        if "dropped" in self.results:
            droppedunknowncount = 0
            for dropped in self.results["dropped"]:
                mimetype = dropped["type"]
                filename = dropped["name"]
                if mimetype == "data" and ".tmp" not in filename:
                    droppedunknowncount += 1            
            if droppedunknowncount > 50:
                self.data.append({"drops_unknown_mimetypes" : "Drops %s unknown file mime types which may be indicative of encrypted files being written back to disk" % (droppedunknowncount)})
                ret = True 

I wanted it to take the value in droppedcount and update it so it would be a message like "Drops 3243 unknown file mime types indicative of ransomware writing encrypted files back to disk" with the 3243 but for some reason this wouldn't take as I expected so I have left it as this for now. With this and the filemove signatures however it seems to cover most ransomware file modification activity.