### PR TITLE
Update martians sig

### DIFF
--- a/modules/signatures/windows/martians.py
+++ b/modules/signatures/windows/martians.py
@@ -1,8 +1,11 @@
-# Copyright (C) 2016 Cuckoo Foundation.
+# Copyright (C) 2016 Cuckoo Foundation. Kevin Ross, Will Metcalf, Brad Spengler. Code used from https://raw.githubusercontent.com/spender-sandbox/community-modified/master/modules/signatures/martians_ie.py
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
-import re
+try:
+    import re2 as re
+except ImportError:
+    import re
 
 from lib.cuckoo.common.abstracts import Signature
 
@@ -10,17 +13,55 @@ class IEMartian(Signature):
     name = "ie_martian"
     description = "Internet Explorer creates one or more martian processes"
     severity = 3
-    categories = ["martian"]
-    authors = ["Cuckoo Technologies"]
+    categories = ["martian", "exploit", "payload"]
+    authors = ["Cuckoo Technologies", "Will Metcalf", "Kevin Ross"]
     minimum = "2.0"
 
     whitelist_re = [
         "\\\"C:\\\\\Program\\ Files(\\ \\(x86\\))?\\\\Internet\\ Explorer\\\\iexplore\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Program Files(?:\s\\(x86\\))?\\\\Adobe\\\\Reader\\ \\d+\\.\\d+\\\\Reader\\\\AcroRd32\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Program Files(?:\s\\(x86\\))?\\\\Java\\\\jre\\d+\\\\bin\\\\j(?:avaw?|p2launcher)\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Program Files(?:\s\\(x86\\))?\\\\Microsoft SilverLight\\\\(?:\\d+\\.)+\\d\\\\agcp.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\System32\\\\ntvdm\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\system32\\\\rundll32\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\syswow64\\\\rundll32\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\system32\\\\drwtsn32\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\syswow64\\\\drwtsn32\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\system32\\\\dwwin\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\system32\\\\WerFault\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+        "\\\"C\\:\\\\Windows\\\\syswow64\\\\WerFault\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
     ]
 
     def on_complete(self):
         for process in self.get_results("behavior", {}).get("generic", []):
             if process["process_name"] != "iexplore.exe":
+                continue
+
+            for cmdline in process.get("summary", {}).get("command_line", []):
+                for regex in self.whitelist_re:
+                    if re.match(regex, cmdline, re.I):
+                        break
+                else:
+                    self.mark_ioc("cmdline", cmdline)
+
+        return self.has_marks()
+
+
+class WscriptMartian(Signature):
+    name = "wscript_martian"
+    description = "Wscript.exe creates one or more martian processes"
+    severity = 3
+    categories = ["martian", "downloader"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    whitelist_re = [
+        "\\\"C:\\\\\Windows\\\\System32\\\\wscript\\.exe\\\"\\ SCODEF:\\d+ CREDAT:\\d+$",
+    ]
+
+    def on_complete(self):
+        for process in self.get_results("behavior", {}).get("generic", []):
+            if process["process_name"] != "wscript.exe":
                 continue
 
             for cmdline in process.get("summary", {}).get("command_line", []):


### PR DESCRIPTION
Changes are:

- Add in signature for wscript martians
- Imported whitelist from https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/martians_ie.py. These need to be checked for the regex as was unable to sanity check but they are required. The reason for whitespace check is mainly here where in original there is missing backslashes adn it appears extra backslash too after c:\ as there is 5 instad of 4 I would have expected myself:
Cuckoo: C:\\\\\Program\\ Files(\\ \\(x86\\))?
Cuckoo modified: C\\:\\\\Program Files(?:\s\\(x86\\))?
-, I wanted to but was unable to port the martians office signature from cuckoo-modified into this format. Could it be added if possible for whitelist adn office martians for the various processes? https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/martians_office.py