### PR TITLE
Create new sig for using computer details in c2

### DIFF
--- a/modules/signatures/windows/infostealer_c2details.py
+++ b/modules/signatures/windows/infostealer_c2details.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class InfoStealerC2Details(Signature):
+    name = "infostealer_c2_details"
+    description = "Queried details from the computer were then used in a network or crypto API call indicative of command and control communications/preperations"
+    severity = 3
+    categories = ["infostealer","c2","network"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.computerdetails = []
+
+    filter_apinames = set(["GetComputerNameA","GetUserNameA","CryptHashData","HttpSendRequestW","HttpOpenRequestW","InternetCrackUrlW","WSASend"])
+    filter_analysistypes = set(["file"])
+
+    def on_call(self, call, process):
+        # Here we check for interesting bits of data which may be queried and used in cnc for computer identification
+        if call["api"] == "GetComputerNameA":
+            compname = call["arguments"]["computer_name"]
+            if compname:
+                self.computerdetails.append(compname)
+
+        if call["api"] == "GetUserNameA":
+            compname = call["arguments"]["user_name"]
+            if compname:
+                self.computerdetails.append(compname)
+
+        # Here we check for the interesting data appearing in buffers from network and crypto calls
+        elif call["api"] == "CryptHashData":
+            buff = call["arguments"]["buffer"]
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    self.mark_call()
+
+        elif call["api"] == "HttpSendRequestW":
+            buff = call["arguments"]["post_data"]
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    self.mark_call()
+
+        elif call["api"] == "HttpOpenRequestW":
+            buff = call["arguments"]["path"]
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    self.mark_call()
+
+        elif call["api"] == "InternetCrackUrlW":
+            buff = call["arguments"]["url"]
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    self.mark_call()
+
+        elif call["api"] == "WSASend":
+            buff = call["arguments"]["buffer"]
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()

--- a/modules/signatures/windows/infostealer_c2details.py
+++ b/modules/signatures/windows/infostealer_c2details.py
@@ -44,36 +44,36 @@ class InfoStealerC2Details(Signature):
 
         # Here we check for the interesting data appearing in buffers from network and crypto calls
         elif call["api"] == "CryptHashData":
-            buff = call["arguments"]["buffer"]
             if len(self.computerdetails) > 0:
+                buff = call["arguments"]["buffer"]
                 for compdetails in self.computerdetails:
                     if compdetails in buff:
                         self.mark_call()
 
         elif call["api"] == "HttpSendRequestW":
-            buff = call["arguments"]["post_data"]
             if len(self.computerdetails) > 0:
+                buff = call["arguments"]["post_data"]
                 for compdetails in self.computerdetails:
                     if compdetails in buff:
                         self.mark_call()
 
         elif call["api"] == "HttpOpenRequestW":
-            buff = call["arguments"]["path"]
             if len(self.computerdetails) > 0:
+                buff = call["arguments"]["path"]
                 for compdetails in self.computerdetails:
                     if compdetails in buff:
                         self.mark_call()
 
         elif call["api"] == "InternetCrackUrlW":
-            buff = call["arguments"]["url"]
             if len(self.computerdetails) > 0:
+                buff = call["arguments"]["url"]
                 for compdetails in self.computerdetails:
                     if compdetails in buff:
                         self.mark_call()
 
         elif call["api"] == "WSASend":
-            buff = call["arguments"]["buffer"]
             if len(self.computerdetails) > 0:
+                buff = call["arguments"]["buffer"]
                 for compdetails in self.computerdetails:
                     if compdetails in buff:
                         self.mark_call()

--- a/modules/signatures/windows/infostealer_c2details.py
+++ b/modules/signatures/windows/infostealer_c2details.py
@@ -45,33 +45,38 @@ class InfoStealerC2Details(Signature):
         # Here we check for the interesting data appearing in buffers from network and crypto calls
         elif call["api"] == "CryptHashData":
             buff = call["arguments"]["buffer"]
-            for compdetails in self.computerdetails:
-                if compdetails in buff:
-                    self.mark_call()
+            if len(self.computerdetails) > 0:
+                for compdetails in self.computerdetails:
+                    if compdetails in buff:
+                        self.mark_call()
 
         elif call["api"] == "HttpSendRequestW":
             buff = call["arguments"]["post_data"]
-            for compdetails in self.computerdetails:
-                if compdetails in buff:
-                    self.mark_call()
+            if len(self.computerdetails) > 0:
+                for compdetails in self.computerdetails:
+                    if compdetails in buff:
+                        self.mark_call()
 
         elif call["api"] == "HttpOpenRequestW":
             buff = call["arguments"]["path"]
-            for compdetails in self.computerdetails:
-                if compdetails in buff:
-                    self.mark_call()
+            if len(self.computerdetails) > 0:
+                for compdetails in self.computerdetails:
+                    if compdetails in buff:
+                        self.mark_call()
 
         elif call["api"] == "InternetCrackUrlW":
             buff = call["arguments"]["url"]
-            for compdetails in self.computerdetails:
-                if compdetails in buff:
-                    self.mark_call()
+            if len(self.computerdetails) > 0:
+                for compdetails in self.computerdetails:
+                    if compdetails in buff:
+                        self.mark_call()
 
         elif call["api"] == "WSASend":
             buff = call["arguments"]["buffer"]
-            for compdetails in self.computerdetails:
-                if compdetails in buff:
-                    self.mark_call()
+            if len(self.computerdetails) > 0:
+                for compdetails in self.computerdetails:
+                    if compdetails in buff:
+                        self.mark_call()
 
     def on_complete(self):
         return self.has_marks()

--- a/modules/signatures/windows/network_c2details.py
+++ b/modules/signatures/windows/network_c2details.py
@@ -38,9 +38,9 @@ class NetworkC2Details(Signature):
                 self.computerdetails.append(compname)
 
         if call["api"] == "GetUserNameA":
-            compname = call["arguments"]["user_name"]
-            if compname:
-                self.computerdetails.append(compname)
+            username = call["arguments"]["user_name"]
+            if username:
+                self.computerdetails.append(username)
 
         # Here we check for the interesting data appearing in buffers from network and crypto calls
         elif call["api"] == "CryptHashData":

--- a/modules/signatures/windows/network_c2details.py
+++ b/modules/signatures/windows/network_c2details.py
@@ -37,7 +37,7 @@ class NetworkC2Details(Signature):
             if compname:
                 self.computerdetails.append(compname)
 
-        if call["api"] == "GetUserNameA":
+        elif call["api"] == "GetUserNameA":
             username = call["arguments"]["user_name"]
             if username:
                 self.computerdetails.append(username)

--- a/modules/signatures/windows/network_c2details.py
+++ b/modules/signatures/windows/network_c2details.py
@@ -32,42 +32,43 @@ class NetworkC2Details(Signature):
 
     def on_call(self, call, process):
         # Here we check for interesting bits of data which may be queried and used in cnc for computer identification
-        if call["api"] == "GetComputerNameA" or call["api"] == "GetComputerNameW":
+        api = call["api"]
+        if api == "GetComputerNameA" or api == "GetComputerNameW":
             compname = call["arguments"]["computer_name"]
             if compname:
                 self.computerdetails.append(compname)
 
-        if call["api"] == "GetUserNameA" or call["api"] == "GetUserNameW":
+        if api == "GetUserNameA" or api == "GetUserNameW":
             compname = call["arguments"]["user_name"]
             if compname:
                 self.computerdetails.append(compname)
 
         # Here we check for the interesting data appearing in buffers from network and crypto calls
-        elif call["api"] == "CryptHashData":
+        elif api == "CryptHashData":
             buff = call["arguments"]["buffer"]
             for compdetails in self.computerdetails:
                 if compdetails in buff:
                     self.mark_call()
 
-        elif call["api"] == "HttpSendRequestW":
+        elif api == "HttpSendRequestW":
             buff = call["arguments"]["post_data"]
             for compdetails in self.computerdetails:
                 if compdetails in buff:
                     self.mark_call()
 
-        elif call["api"] == "HttpOpenRequestW":
+        elif api == "HttpOpenRequestW":
             buff = call["arguments"]["path"]
             for compdetails in self.computerdetails:
                 if compdetails in buff:
                     self.mark_call()
 
-        elif call["api"] == "InternetCrackUrlW":
+        elif api == "InternetCrackUrlW":
             buff = call["arguments"]["url"]
             for compdetails in self.computerdetails:
                 if compdetails in buff:
                     self.mark_call()
 
-        elif call["api"] == "WSASend":
+        elif api == "WSASend":
             buff = call["arguments"]["buffer"]
             for compdetails in self.computerdetails:
                 if compdetails in buff:

--- a/modules/signatures/windows/network_c2details.py
+++ b/modules/signatures/windows/network_c2details.py
@@ -15,11 +15,11 @@
 
 from lib.cuckoo.common.abstracts import Signature
 
-class InfoStealerC2Details(Signature):
-    name = "infostealer_c2_details"
+class NetworkC2Details(Signature):
+    name = "network_c2_details"
     description = "Queried details from the computer were then used in a network or crypto API call indicative of command and control communications/preperations"
     severity = 3
-    categories = ["infostealer","c2","network"]
+    categories = ["c2","network","infostealer"]
     authors = ["Kevin Ross"]
     minimum = "2.0"
 


### PR DESCRIPTION
This sig simply started when looking at Dridex. The intention is that various bits of information used in C2 construction for identification of the computer when they are queried can then be looked for in Crypto calls (for hashing the data before sending it as malware does) or directly in network traffic.

Right now it is only looking for username & computer name but this could be expanded to include checks for:
- IP Address
- MAC Address
- AV installed?
- Product ID
  And so on.

Still it could be grown into a useful sig for identifying how bits of information from the computer are then used in C2 although it will take some research & testing to implement further checks.
