### PR TITLE
Update persistance locations and methods

### DIFF
--- a/modules/signatures/windows/persistence_autorun.py
+++ b/modules/signatures/windows/persistence_autorun.py
@@ -29,7 +29,7 @@ class Autorun(Signature):
     description = "Installs itself for autorun at Windows startup"
     severity = 3
     categories = ["persistence"]
-    authors = ["Michael Boman", "nex", "securitykitten", "Cuckoo Technologies", "Optiv", "KillerInstinct"]
+    authors = ["Michael Boman", "nex", "securitykitten", "Cuckoo Technologies", "Optiv", "KillerInstinct", "Kevin Ross"]
     minimum = "2.0"
 
     regkeys_re = [
@@ -53,7 +53,7 @@ class Autorun(Signature):
         ".*\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\ShellServiceObjectDelayLoad\\\\.*",
         ".*\\\\System\\\\(CurrentControlSet|ControlSet001)\\\\Control\\\\Session\\ Manager\\\\AppCertDlls\\\\.*",
         ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\InprocServer32\\\\.*",
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\LocalServer32\\\\.*"
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\LocalServer32\\\\.*",
     ]
 
     files_re = [
@@ -80,8 +80,10 @@ class Autorun(Signature):
             servicename = call["arguments"]["service_name"]
             servicepath = call["arguments"]["filepath"]
             if starttype < 3:
-                self.mark_ioc("service name", servicename)
-                self.mark_ioc("service path", servicepath)
+                self.mark(
+                    service_name=servicename,
+                    service_path=servicepath,
+                )
 
         elif call["status"]:
             regkey = call["arguments"]["regkey"]
@@ -94,8 +96,10 @@ class Autorun(Signature):
             if not in_whitelist:
                 for indicator in self.regkeys_re:
                     if re.match(indicator, regkey, re.IGNORECASE) and regvalue != "c:\\program files\\java\\jre7\\bin\jp2iexp.dll":
-                        self.mark_ioc("registry key", regkey)
-                        self.mark_ioc("registry value", regvalue)
+                        self.mark(
+                            reg_key=regkey,
+                            reg_value=regvalue,
+                        )
 
     def on_complete(self):
         for indicator in self.files_re:

--- a/modules/signatures/windows/persistence_autorun.py
+++ b/modules/signatures/windows/persistence_autorun.py
@@ -83,13 +83,19 @@ class Autorun(Signature):
                 self.mark_ioc("service name", servicename)
                 self.mark_ioc("service path", servicepath)
 
-        elif call["api"] == "RegSetValueExA":
+        elif call["api"] == "RegSetValueExA" or call["api"] == "RegSetValueExW" or call["api"] == "NtSetValueKey":
             regkey = call["arguments"]["regkey"]
             regvalue = call["arguments"]["value"]
-            for indicator in self.regkeys_re:
-                if re.match(indicator, regkey):
-                    self.mark_ioc("registry key", regkey)
-                    self.mark_ioc("registry value", regvalue)
+            in_whitelist = False
+            for whitelist in self.whitelists:
+                if re.match(whitelist, regkey, re.IGNORECASE):
+                    in_whitelist = True
+                    break
+            if not in_whitelist:
+                for indicator in self.regkeys_re:
+                    if re.match(indicator, regkey, re.IGNORECASE) and regvalue != "c:\\program files\\java\\jre7\\bin\jp2iexp.dll":
+                        self.mark_ioc("registry key", regkey)
+                        self.mark_ioc("registry value", regvalue)
 
     def on_complete(self):
         for indicator in self.files_re:

--- a/modules/signatures/windows/persistence_autorun.py
+++ b/modules/signatures/windows/persistence_autorun.py
@@ -83,7 +83,7 @@ class Autorun(Signature):
                 self.mark_ioc("service name", servicename)
                 self.mark_ioc("service path", servicepath)
 
-        elif call["api"] == "RegSetValueExA" or call["api"] == "RegSetValueExW" or call["api"] == "NtSetValueKey":
+        elif call["status"]:
             regkey = call["arguments"]["regkey"]
             regvalue = call["arguments"]["value"]
             in_whitelist = False

--- a/modules/signatures/windows/persistence_autorun.py
+++ b/modules/signatures/windows/persistence_autorun.py
@@ -72,7 +72,13 @@ class Autorun(Signature):
         ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\InprocServer32\\\\ThreadingModel$"
     ]
 
-    filter_apinames = set(["RegSetValueExA", "RegSetValueExW", "NtSetValueKey", "CreateServiceA", "CreateServiceW"])
+    filter_apinames = [
+        "RegSetValueExA",
+        "RegSetValueExW",
+        "NtSetValueKey",
+        "CreateServiceA",
+        "CreateServiceW",
+    ]
 
     def on_call(self, call, process):
         if call["api"] == "CreateServiceA" or call["api"] == "CreateServiceW":


### PR DESCRIPTION
I originally was not going to sort out the signatures that exist between cuckoo-modified & cuckoo 2.0 until the based signatures were the same. However as I was having problems with this not firing I have updated it from this:

https://raw.githubusercontent.com/spender-sandbox/community-modified/master/modules/signatures/persistence_autorun.py

I have not included the whitelist that exists on the cuckoo-modified signature and I am aware some of the API stuff overlaps the service creation signature but the main check is the start type. I was going to just update the service creation signature but I decided against it as I would rather present service creation for autoruns showing with the rest of them. However it does result in a weird combined registry/API call results when the self.marks are reported. Still it looks ok and communicates this is persitance fine & these updates also fix the issues with the Wow6432Node keys not being fired on.
