### PR TITLE
Update mail stealer sig

### DIFF
--- a/modules/signatures/windows/infostealer_mail.py
+++ b/modules/signatures/windows/infostealer_mail.py
@@ -22,6 +22,13 @@ class MailStealer(Signature):
         ".*\\\\Microsoft\\\\Internet\\ Account\\ Manager\\\\Accounts.*",
         ".*\\\\Software\\\\(Wow6432Node\\\\)?IncrediMail.*"
         ".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\ Live\\ Mail.*",
+        ".*\\\\RIT\\\\The\\ Bat\\!",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\ Mail",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?RimArts\\\\B2\\\\Settings",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Poco\\ Systems\\ Inc",
+        ".*\\\\Software\\\\Mozilla\\\\Mozilla\\ Thunderbird",
+        # Well, strictly speaking..
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Google\\\\Google\\ Talk",
     ]
 
     files_re = [

--- a/modules/signatures/windows/infostealer_mail.py
+++ b/modules/signatures/windows/infostealer_mail.py
@@ -40,6 +40,7 @@ class MailStealer(Signature):
         ".*\\\\Foxmail.*\\\\Accounts\.tdat$",
         ".*\\\\Thunderbird\\\\Profiles\\\\.*\.default$",
         ".*\\\\AppData\\\\Roaming\\\\Thunderbird\\\\profiles.ini$",
+         ".*\\\\The\\ Bat!\\\\",
     ]
 
     # To be replaced by a check_file(dirs=True) whenever we can do that in a

--- a/modules/signatures/windows/infostealer_mail.py
+++ b/modules/signatures/windows/infostealer_mail.py
@@ -13,27 +13,26 @@ class MailStealer(Signature):
     minimum = "2.0"
 
     regkeys_re = [
-        ".*\\\\Software\\\\IncrediMail",
-        ".*\\\\RIT\\\\The\\ Bat\\!",
-        ".*\\\\Microsoft\\\\Internet\\ Account\\ Manager\\\\Accounts",
-        ".*\\\\Software\\\\Microsoft\\\\Windows\\ Mail",
-        ".*\\\\Software\\\\Microsoft\\\\Windows\\ Live\\ Mail",
-        ".*\\\\Software\\\\Microsoft\\\\Windows\\ NT\\\\CurrentVersion\\\\Windows\\ Messaging\\ Subsystem",
-        ".*\\\\Software\\\\Microsoft\\\\Internet\\ Account\\ Manager",
-        ".*\\\\Software\\\\Microsoft\\\\Office\\\\Outlook\\\\OMI\\ Account\\ Manager",
-        ".*\\\\Software\\\\RimArts\\\\B2\\\\Settings",
-        ".*\\\\Software\\\\Poco\\ Systems\\ Inc",
-        ".*\\\\Software\\\\Mozilla\\\\Mozilla\\ Thunderbird",
-        # Well, strictly speaking..
-        ".*\\\\Software\\\\Google\\\\Google\\ Talk",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Clients\\\\Mail.*",
+        ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\MSMapiApps.*",
+        ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\Profiles.*",
+        ".*\\\\Microsoft\\\\Windows\\ NT\\\\CurrentVersion\\\\Windows\\ Messaging\\ Subsystem\\\\Profiles.*",
+        ".*\\\\Microsoft\\\\Office\\\\.*\\\\Outlook\\\\Profiles\\\\Outlook.*",
+        ".*\\\\Microsoft\\\\Office\\\\Outlook\\\\OMI\\ Account\\ Manager\\\\Accounts.*",
+        ".*\\\\Microsoft\\\\Internet\\ Account\\ Manager\\\\Accounts.*",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?IncrediMail.*"
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\ Live\\ Mail.*",
     ]
 
     files_re = [
-        ".*\\\\The\\ Bat!\\\\",
-        ".*\\\\ICQ\\\\",
-        ".*\\\\Miranda\\\\",
-        ".*\\\\SmartFTP\\\\",
-        ".*\\\\QIP\\\\",
+        ".*\.pst$",
+        ".*\\\\Microsoft\\\\Windows\\ Live\\ Mail.*",
+        ".*\\\\Microsoft\\\\Address\\ Book\\\\.*\.wab$",
+        ".*\\\\Microsoft\\\\Outlook\\ Express\\\\.*\.dbx$",
+        ".*\\\\Foxmail\\\\mail\\\\.*\\\\Account\.stg$",
+        ".*\\\\Foxmail.*\\\\Accounts\.tdat$",
+        ".*\\\\Thunderbird\\\\Profiles\\\\.*\.default$",
+        ".*\\\\AppData\\\\Roaming\\\\Thunderbird\\\\profiles.ini$",
     ]
 
     # To be replaced by a check_file(dirs=True) whenever we can do that in a

--- a/modules/signatures/windows/infostealer_mail.py
+++ b/modules/signatures/windows/infostealer_mail.py
@@ -13,25 +13,31 @@ class MailStealer(Signature):
     minimum = "2.0"
 
     regkeys_re = [
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?Clients\\\\Mail.*",
-        ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\MSMapiApps.*",
-        ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\Profiles.*",
-        ".*\\\\Microsoft\\\\Windows\\ NT\\\\CurrentVersion\\\\Windows\\ Messaging\\ Subsystem\\\\Profiles.*",
-        ".*\\\\Microsoft\\\\Office\\\\.*\\\\Outlook\\\\Profiles\\\\Outlook.*",
-        ".*\\\\Microsoft\\\\Office\\\\Outlook\\\\OMI\\ Account\\ Manager\\\\Accounts.*",
-        ".*\\\\Microsoft\\\\Internet\\ Account\\ Manager\\\\Accounts.*",
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?IncrediMail.*"
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\ Live\\ Mail.*",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?IncrediMail"
         ".*\\\\RIT\\\\The\\ Bat\\!",
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\ Mail",
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?RimArts\\\\B2\\\\Settings",
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?Poco\\ Systems\\ Inc",
+        ".*\\\\Microsoft\\\\Internet\\ Account\\ Manager\\\\Accounts",
+        ".*\\\\Software\\\\Microsoft\\\\Windows\\ Mail",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\ Live\\ Mail",
+        ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\MSMapiApps",
+        ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\Profiles.*",
+        ".*\\\\Software\\\\Microsoft\\\\Windows\\ NT\\\\CurrentVersion\\\\Windows\\ Messaging\\ Subsystem",
+        ".*\\\\Software\\\\Microsoft\\\\Internet\\ Account\\ Manager",
+        ".*\\\\Software\\\\Microsoft\\\\Office\\\\Outlook\\\\OMI\\ Account\\ Manager",
+        ".*\\\\Software\\\\RimArts\\\\B2\\\\Settings",
+        ".*\\\\Software\\\\Poco\\ Systems\\ Inc",
         ".*\\\\Software\\\\Mozilla\\\\Mozilla\\ Thunderbird",
+        ".*\\\\Software\\\\(Wow6432Node\\\\)?Clients\\\\Mail",
+        ".*\\\\Microsoft\\\\Office\\\\.*\\\\Outlook\\\\Profiles\\\\Outlook",
         # Well, strictly speaking..
-        ".*\\\\Software\\\\(Wow6432Node\\\\)?Google\\\\Google\\ Talk",
+        ".*\\\\Software\\\\Google\\\\Google\\ Talk",
     ]
 
     files_re = [
+        ".*\\\\The\\ Bat!\\\\",
+        ".*\\\\ICQ\\\\",
+        ".*\\\\Miranda\\\\",
+        ".*\\\\SmartFTP\\\\",
+        ".*\\\\QIP\\\\",
         ".*\.pst$",
         ".*\\\\Microsoft\\\\Windows\\ Live\\ Mail.*",
         ".*\\\\Microsoft\\\\Address\\ Book\\\\.*\.wab$",
@@ -40,7 +46,6 @@ class MailStealer(Signature):
         ".*\\\\Foxmail.*\\\\Accounts\.tdat$",
         ".*\\\\Thunderbird\\\\Profiles\\\\.*\.default$",
         ".*\\\\AppData\\\\Roaming\\\\Thunderbird\\\\profiles.ini$",
-         ".*\\\\The\\ Bat!\\\\",
     ]
 
     # To be replaced by a check_file(dirs=True) whenever we can do that in a


### PR DESCRIPTION
Update to match cuckoo-modified signature (some things are IM in the original sig or an FTP client which is covered/can be covered by other sigs. Indicaotrs from here:

https://github.com/spender-sandbox/community-modified/blob/6ec2db86410d892eb509ba1b5fb6d869e6e8636f/modules/signatures/infostealer_mail.py
