### PR TITLE
Add in stealth child process sig

### DIFF
--- a/modules/signatures/windows/stealth_childproc.py
+++ b/modules/signatures/windows/stealth_childproc.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2014 Optiv, Inc. (brad.spengler@optiv.com), Updated 2016 for cuckoo 2.0
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class StealthChildProc(Signature):
+    name = "stealth_childproc"
+    description = "Forces a created process to be the child of an unrelated process"
+    severity = 3
+    categories = ["stealth"]
+    authors = ["Optiv"]
+    minimum = "2.0"
+
+    filter_apinames = set(["NtCreateProcess","NtCreateProcessEx","RtlCreateUserProcess","CreateProcessInternalW"])
+
+    def on_call(self, call, process):
+        parenthandle = call["arguments"]["parent_handle"]
+        if parenthandle and parenthandle != "0xffffffff" and parenthandle != "0xffffffffffffffff":
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()


### PR DESCRIPTION
This is a cuckoo-modified signature: https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/stealth_childproc.py

I can't find examples currently to properly test but as long as the parent_handle exists and is correct option in cuckoo 2.0 I can't see why this wouldn't work but it would be good if this can be tested as it is a straight conversion although I need to find an API call with the parent_handle argument to confirm but thowing this out there now in case someone else can ensure it is correct.