### PR TITLE
remove autorun.inf "FP"

### DIFF
--- a/modules/signatures/windows/worm_renocide.py
+++ b/modules/signatures/windows/worm_renocide.py
@@ -20,7 +20,6 @@ class Renocide(Signature):
 
     files_re = [
         ".*95a1sd\\.xx",
-        ".*autorun\\.i",
         ".*\\\\Temp\\\\nrrtrvm",
         ".*\\\\Temp\\\\aut1\\.tmp",
     ]


### PR DESCRIPTION
This is not tied specifically to this worm but really any autospreading worm and is not a good IOC. As I look through these signatures though I see IOCs specific to versions or even specific executions of malware, hardcoded IPs at times which are likely to change and so on & so I would say that it may be worth these being redone to actually focus on behavioural indicators rather than specific IOCs at a point in time which also have included standard registry keys, files like autorun.inf which would be anything etc.