### PR TITLE
Update creates service

### DIFF
--- a/modules/signatures/windows/creates_service.py
+++ b/modules/signatures/windows/creates_service.py
@@ -8,7 +8,7 @@ class CreatesService(Signature):
     name = "creates_service"
     description = "Creates a service"
     severity = 2
-    categories = ["service", "persistance"]
+    categories = ["service", "persistence"]
     authors = ["Cuckoo Technologies", "Kevin Ross"]
     minimum = "2.0"
 


### PR DESCRIPTION
Modify creates service signature to support functionality of detecting a service which has not been started. This brings over the idea of this signature but unfortunately because the stopped/started service stuff is handled a different way in cuckoo-modified it was not possible to actualy conver the signature directly so the concept had to be implemented instead.

https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/persistence_service.py