### PR TITLE
Create signature for self deletion

### DIFF
--- a/modules/signatures/deletes_self.py
+++ b/modules/signatures/deletes_self.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2014 Optiv Inc. (brad.spengler@optiv.com), Converted 2016 for Cuckoo 2.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class DeletesSelf(Signature):
+    name = "deletes_self"
+    description = "Deletes its original binary from disk"
+    severity = 3
+    categories = ["persistence", "stealth"]
+    authors = ["Optiv", "Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+
+    def on_complete(self):
+        processes = []
+        for process in self.get_results("behavior", {}).get("generic", []):
+            for cmdline in process.get("summary", {}).get("command_line", []):
+                processes.append(cmdline)
+
+        for deletedfile in self.get_files(actions=["file_deleted"]):
+            if deletedfile in processes[0]:
+                self.mark_ioc("file", deletedfile)
+
+        return self.has_marks()


### PR DESCRIPTION
The concept of this signature is from the cuckoo-modified signature https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/deletes_self.py.

However I have rewritten its operation due to some differences so the way this is detected is not achieved the same way as the original signature so I have also put my name on this due to it being more than a simple signature upgrade. The logic is basically put all processes into a list and then check if a deleted file exists in position 0 (first process) for a match.

It has been tested on several malware samples which deletes their original binary such as TeslaCrypt and it works fine.