### PR TITLE
Add in signature for creating ransomware message

### DIFF
--- a/modules/signatures/windows/ransomware_message.py
+++ b/modules/signatures/windows/ransomware_message.py
@@ -1,0 +1,107 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+try:
+    import re2 as re
+except ImportError:
+    import re
+
+class RansomwareMessage(Signature):
+    name = "ransomware_message"
+    description = "Writes a potential ransom message to disk"
+    severity = 3
+    categories = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.indicators = [
+            "your files",
+            "your data",
+            "your documents",
+            "restore files",
+            "restore data",
+            "restore the files",
+            "restore the data",
+            "recover files",
+            "recover data"
+            "recover the files",
+            "recover the data",
+            "has been locked",
+            "pay fine",
+            "pay a fine",
+            "pay the fine",
+            "decrypt",
+            "encrypt",
+            "recover files",
+            "recover data",
+            "recover them",
+            "recover your",
+            "recover personal",
+            "bitcoin",
+            "secret server",
+            "secret internet server",
+            "install tor",
+            "download tor",
+            "tor browser",
+            "tor gateway",
+            "tor-browser",
+            "tor-gateway",
+            "torbrowser",
+            "torgateway",
+            "torproject.org",
+            "ransom",
+            "bootkit",
+            "rootkit",
+            "payment",
+            "AES128",
+            "AES256",
+            "AES 128",
+            "AES 256",
+            "AES-128",
+            "AES-256",
+            "RSA1024",
+            "RSA2048",
+            "RSA4096",
+            "RSA 1024",
+            "RSA 2048",
+            "RSA 4096",
+            "RSA-1024",
+            "RSA-2048",
+            "RSA-4096",
+            "private key",
+            "personal key",
+            "your code",
+            "private code",
+            "personal code",
+            "enter code",
+            "your key",
+            "unique key"
+    ]
+
+    filter_apinames = set(["NtWriteFile"])
+
+    def on_call(self, call, process):
+        buff = call["arguments"]["buffer"].lower()
+        if len(buff) >= 128:
+            patterns = "|".join(self.indicators)
+            if len(re.findall(patterns, buff)) > 1:
+                self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()

--- a/modules/signatures/windows/ransomware_message.py
+++ b/modules/signatures/windows/ransomware_message.py
@@ -93,16 +93,32 @@ class RansomwareMessage(Signature):
             "enter code",
             "your key",
             "unique key"
-    ]
+        ]
+
+        self.whitelistprocs = [
+            "iexplore.exe",
+            "firefox.exe",
+            "chrome.exe",
+            "safari.exe",
+            "acrord32.exe",
+            "acrord64.exe",
+            "wordview.exe",
+            "winword.exe",
+            "excel.exe",
+            "powerpnt.exe",
+            "outlook.exe",
+            "mspub.exe"
+        ]
 
     filter_apinames = set(["NtWriteFile"])
 
     def on_call(self, call, process):
-        buff = call["arguments"]["buffer"].lower()
-        if len(buff) >= 128:
-            patterns = "|".join(self.indicators)
-            if len(re.findall(patterns, buff)) > 1:
-                self.mark_call()
+        if process["process_name"].lower() not in self.whitelistprocs:
+            buff = call["arguments"]["buffer"].lower()
+            if len(buff) >= 128:
+                patterns = "|".join(self.indicators)
+                if len(re.findall(patterns, buff)) > 1:
+                    self.mark_call()
 
     def on_complete(self):
         return self.has_marks()

--- a/modules/signatures/windows/ransomware_message.py
+++ b/modules/signatures/windows/ransomware_message.py
@@ -69,6 +69,7 @@ class RansomwareMessage(Signature):
             "bootkit",
             "rootkit",
             "payment",
+            "victim",
             "AES128",
             "AES256",
             "AES 128",


### PR DESCRIPTION
This is a conversion of this signature I put together for cuckoo-modified https://github.com/spender-sandbox/community-modified/pull/157. The concerns that were raised during my initial submission of that signature around performance for looking at every NTWriteFile call stands for this signature. On the other one I got round the performance issues by:
- For NTWriteFile only looking for bootkit modifications
- For files actually written to disk looking through dropped files as cuckoo-modified shows the first 4KB.
- NtWriteFile doesn't actually show the written file name it seems in the cuckoo 2.0 reports, just buffer and filehandle.

With this one however I am closer to my original sig but with some performance and accuracy improvements but I have tested with ransomware & it works fine.
