### PR TITLE
Add in signature for creating large regvalues (i.e malware configs)

### DIFF
--- a/modules/signatures/windows/creates_largekey.py
+++ b/modules/signatures/windows/creates_largekey.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2015 Optiv Inc. (brad.spengler@optiv.com), Updated 2016 for Cuckoo 2.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class CreatesLargeKey(Signature):
+    name = "creates_largekey"
+    description = "Creates or sets a registry key to a long series of bytes, possibly to store a binary or malware config"
+    severity = 3
+    confidence = 80
+    categories = ["stealth"]
+    authors = ["Optiv"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.saw_large = False
+        self.regkeyvals = set()
+    filter_apinames = set(["NtSetValueKey", "RegSetValueExA", "RegSetValueExW"])
+
+    def on_call(self, call, process):
+        vallen = len(call["arguments"]["value"])
+        if vallen:
+            length = int(vallen)
+            if length > 16 * 1024:
+                self.regkeyvals.add(call["arguments"]["regkey"])
+                self.saw_large = True
+
+    def on_complete(self):
+        if self.saw_large:
+            for keyval in self.regkeyvals:
+                self.mark_ioc("registry", keyval)
+
+        return self.has_marks()

--- a/modules/signatures/windows/creates_largekey.py
+++ b/modules/signatures/windows/creates_largekey.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys
+
 from lib.cuckoo.common.abstracts import Signature
 
 class CreatesLargeKey(Signature):
@@ -32,7 +34,7 @@ class CreatesLargeKey(Signature):
     filter_apinames = set(["NtSetValueKey", "RegSetValueExA", "RegSetValueExW"])
 
     def on_call(self, call, process):
-        vallen = len(call["arguments"]["value"])
+        vallen = sys.getsizeof(call["arguments"]["value"])
         if vallen:
             length = int(vallen)
             if length > 16 * 1024:


### PR DESCRIPTION
Converted cuckoo-modified sig: https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/creates_largekey.py

Tested on recent Kovter sample md5: 78c622b295114aa0004b2a8cba8df371. Also worth noting that the process tree does not appear to show every child and created process although no injection is used when comparing when I was converted the sig although I have not determined what is actually different although various malicious actions are missed so maybe another sample worth looking at similar to my raised "injection not followed" issue
