### PR TITLE
Update heapspray signature & add in new exploit detections (stack/heap/dep)

### DIFF
--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -17,6 +17,14 @@ class ExploitHeapspray(Signature):
     def init(self):
         self.mem = {}
         self.prot = {}
+        self.ignore = False
+        self.whitelist = ["PE32 executable"]
+        
+        if self.get_results("target", {}).get("category") == "file":
+            filetype = self.get_results("target", {})["file"]["type"]
+            for ignore in self.whitelist:
+                if ignore in filetype:
+                    self.ignore = True
 
     def on_call(self, call, process):
         pname = process["process_name"]
@@ -24,23 +32,27 @@ class ExploitHeapspray(Signature):
         protection = call["arguments"]["protection"]
         alloc_type = call["arguments"]["allocation_type"]
         region_size = call["arguments"]["region_size"]
+        allocation_typefull = call["flags"].get("allocation_type")
 
-        combo = pname, pid, region_size, protection, alloc_type
-        self.mem[combo] = self.mem.get(combo, 0) + 1
-
-        self.prot[protection] = call["flags"].get("protection")
+        if allocation_typefull == "MEM_COMMIT":
+            combo = pname, pid, region_size, protection, alloc_type
+            self.mem[combo] = self.mem.get(combo, 0) + 1
+            self.prot[protection] = call["flags"].get("protection")
 
     def on_complete(self):
-        for combo, count in self.mem.items():
-            pname, pid, region_size, protection, alloc_type = combo
+        if not self.ignore:
+            for combo, count in self.mem.items():
+                pname, pid, region_size, protection, alloc_type = combo
 
-            if count >= 50:
-                self.mark(
-                    process=pname,
-                    name="heapspray",
-                    protection=self.prot.get(protection, protection),
-                    count=count,
-                    length=region_size,
-                )
+                if count >= 50:
+                    written = int(region_size) * int(count)/1024/1024
+                    self.mark(
+                        process=pname,
+                        name="heapspray",
+                        protection=self.prot.get(protection, protection),
+                        count=count,
+                        length=region_size,
+                        total_mb=written,
+                    )
 
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -138,7 +138,7 @@ class DEPHeapBypass(Signature):
         return self.has_marks()
 
 class DEPStackBypass(Signature):
-    name = "dep_heap_bypass"
+    name = "dep_stack_bypass"
     description = "DEP was bypassed by marking part of the stack executable"
     severity = 3
     categories = ["exploit"]

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -120,7 +120,7 @@ class StackPivot(Signature):
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "Stack pivoting was detected when using a critical API in the following processes: "
+            self.description = "Stack pivoting was detected when using a critical API in the processes "
             list = ",".join(self.pname )
             self.description += list
         return self.has_marks()
@@ -158,7 +158,7 @@ class DEPHeapBypass(Signature):
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the heap executable by the following processes: "
+            self.description = "DEP was bypassed by marking part of the heap executable by the processes "
             list = ",".join(self.pname )
             self.description += list
         return self.has_marks()
@@ -196,7 +196,7 @@ class DEPStackBypass(Signature):
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the stack executable by the following processes: "
+            self.description = "DEP was bypassed by marking part of the stack executable by the processes "
             list = ",".join(self.pname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -34,7 +34,7 @@ class ExploitHeapspray(Signature):
         region_size = call["arguments"]["region_size"]
         allocation_typefull = call["flags"].get("allocation_type")
 
-        if allocation_typefull == "MEM_COMMIT":
+        if "MEM_COMMIT" in allocation_typefull:
             combo = pname, pid, region_size, protection, alloc_type
             self.mem[combo] = self.mem.get(combo, 0) + 1
             self.prot[protection] = call["flags"].get("protection")
@@ -46,13 +46,14 @@ class ExploitHeapspray(Signature):
 
                 if count >= 50:
                     written = int(region_size) * int(count)/1024/1024
-                    self.mark(
-                        process=pname,
-                        name="heapspray",
-                        protection=self.prot.get(protection, protection),
-                        count=count,
-                        length=region_size,
-                        total_mb=written,
-                    )
+                    if written >= 20:
+                        self.mark(
+                            process=pname,
+                            name="heapspray",
+                            protection=self.prot.get(protection, protection),
+                            count=count,
+                            length=region_size,
+                            total_mb=written,
+                        )
 
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -127,7 +127,7 @@ class StackPivot(Signature):
 
 class DEPHeapBypass(Signature):
     name = "dep_heap_bypass"
-    description = "DEP was bypassed by marking part of the heap executable following a stack pivot"
+    description = "DEP was bypassed by marking part of the heap executable following stack pivoting"
     severity = 6
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
@@ -154,11 +154,11 @@ class DEPHeapBypass(Signature):
 
     def on_complete(self):
         if len(self.pname) == 1:
-            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot in the process "
+            self.description = "DEP was bypassed by marking part of the heap executable following stack pivoting in the process "
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot in the processes: "
+            self.description = "DEP was bypassed by marking part of the heap executable following stack pivoting in the processes: "
             list = ",".join(self.pname )
             self.description += list
         return self.has_marks()
@@ -250,5 +250,42 @@ class ShellcodeWriteProcessMemory(Signature):
         elif len(self.scpname) > 1:
             self.description = "Found potential shellcode being written to a memory region previously marked executable following DEP bypass in the processes "
             list = ", ".join(self.scpname )
+            self.description += list
+        return self.has_marks()
+
+class StackPivotDllLoad(Signature):
+    name = "stack_pivot_dll_load"
+    description = "DLLs were loaded following stack pivoting indicative of shellcode"
+    severity = 3
+    categories = ["exploit", "rop", "shellcode"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ignore = False
+        self.pname = []
+        if self.get_results("target", {}).get("category") == "file":
+            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
+                self.ignore = True
+
+    filter_apinames = set(["LdrLoadDll"])
+
+    def on_call(self, call, process):
+        if "stack_pivoted" in call["arguments"]:
+            if call["arguments"]["stack_pivoted"] == 1 and not self.ignore:
+                pname = process["process_name"]
+                if pname not in self.pname:
+                    self.pname.append(pname)
+                self.mark_call()
+
+    def on_complete(self):
+        if len(self.pname) == 1:
+            self.description = "DLLs were loaded following stack pivoting indicative of shellcode in the process "
+            for pname in self.pname:
+                self.description += pname
+        elif len(self.pname) > 1:
+            self.description = "DLLs were loaded following stack pivoting indicative of shellcode in the processes "
+            list = ", ".join(self.pname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -90,7 +90,7 @@ class ExploitHeapspray(Signature):
 class StackPivot(Signature):
     name = "stack_pivot"
     description = "Stack pivoting was detected when using a critical API"
-    severity = 3
+    severity = 6
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
@@ -99,6 +99,7 @@ class StackPivot(Signature):
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.ignore = False
+        self.pname = []
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
@@ -106,10 +107,22 @@ class StackPivot(Signature):
     filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
-        if call["arguments"]["stack_pivoted"] == 1 and not self.ignore: 
-            self.mark_call()
+        if "stack_pivoted" in call["arguments"]:
+            if call["arguments"]["stack_pivoted"] == 1 and not self.ignore:
+                pname = process["process_name"]
+                if pname not in self.pname:
+                    self.pname.append(pname)
+                self.mark_call()
 
     def on_complete(self):
+        if len(self.pname) == 1:
+            self.description = "Stack pivoting was detected when using a critical API in the process "
+            for pname in self.pname:
+                self.description += pname
+        elif len(self.pname) > 1:
+            self.description = "Stack pivoting was detected when using a critical API in the following processes: "
+            list = ",".join(self.pname )
+            self.description += list
         return self.has_marks()
 
 class DEPHeapBypass(Signature):
@@ -124,6 +137,7 @@ class DEPHeapBypass(Signature):
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.ignore = False
+        self.pname = []
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
@@ -131,10 +145,22 @@ class DEPHeapBypass(Signature):
     filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
-        if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore: 
-            self.mark_call()
+        if "heap_dep_bypass" in call["arguments"]:
+            if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore:
+                pname = process["process_name"]
+                if pname not in self.pname:
+                    self.pname.append(pname)
+                self.mark_call()
 
     def on_complete(self):
+        if len(self.pname) == 1:
+            self.description = "DEP was bypassed by marking part of the heap executable by the process "
+            for pname in self.pname:
+                self.description += pname
+        elif len(self.pname) > 1:
+            self.description = "DEP was bypassed by marking part of the heap executable by the following processes: "
+            list = ",".join(self.pname )
+            self.description += list
         return self.has_marks()
 
 class DEPStackBypass(Signature):
@@ -149,6 +175,7 @@ class DEPStackBypass(Signature):
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.ignore = False
+        self.pname = []
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
@@ -156,8 +183,20 @@ class DEPStackBypass(Signature):
     filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
-        if call["arguments"]["stack_dep_bypass"] == 1 and not self.ignore: 
-            self.mark_call()
+        if "stack_dep_bypass" in call["arguments"]:
+            if call["arguments"]["stack_dep_bypass"] == 1 and not self.ignore:
+                pname = process["process_name"]
+                if pname not in self.pname:
+                    self.pname.append(pname)
+                self.mark_call()
 
     def on_complete(self):
+        if len(self.pname) == 1:
+            self.description = "DEP was bypassed by marking part of the stack executable by the process "
+            for pname in self.pname:
+                self.description += pname
+        elif len(self.pname) > 1:
+            self.description = "DEP was bypassed by marking part of the stack executable by the following processes: "
+            list = ",".join(self.pname )
+            self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -71,3 +71,96 @@ class ExploitHeapspray(Signature):
                         self.severity = 4
                      
         return self.has_marks()
+        
+        # Copyright (C) 2015 Optiv, Inc. (brad.spengler@optiv.com), Updated 2016 for Cuckoo 2.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+class StackPivot(Signature):
+    name = "stack_pivot"
+    description = "Stack pivoting was detected when using a critical API"
+    weight = 3
+    severity = 3
+    categories = ["exploit"]
+    authors = ["Optiv", "Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ignore = False
+        if self.get_results("target", {}).get("category") == "file":
+            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
+                self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
+
+    def on_call(self, call, process):
+        if call["arguments"]["stack_pivoted"] == 1 and not self.ignore: 
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()
+
+class DEPHeapBypass(Signature):
+    name = "dep_heap_bypass"
+    description = "DEP was bypassed by marking part of the heap executable"
+    weight = 3
+    severity = 3
+    categories = ["exploit"]
+    authors = ["Optiv", "Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ignore = False
+        if self.get_results("target", {}).get("category") == "file":
+            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
+                self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
+
+    def on_call(self, call, process):
+        if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore: 
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()
+
+class DEPStackBypass(Signature):
+    name = "dep_heap_bypass"
+    description = "DEP was bypassed by marking part of the stack executable"
+    weight = 3
+    severity = 3
+    categories = ["exploit"]
+    authors = ["Optiv", "Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ignore = False
+        if self.get_results("target", {}).get("category") == "file":
+            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
+                self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
+
+    def on_call(self, call, process):
+        if call["arguments"]["stack_dep_bypass"] == 1 and not self.ignore: 
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -90,7 +90,6 @@ class ExploitHeapspray(Signature):
 class StackPivot(Signature):
     name = "stack_pivot"
     description = "Stack pivoting was detected when using a critical API"
-    weight = 3
     severity = 3
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
@@ -116,7 +115,6 @@ class StackPivot(Signature):
 class DEPHeapBypass(Signature):
     name = "dep_heap_bypass"
     description = "DEP was bypassed by marking part of the heap executable"
-    weight = 3
     severity = 3
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
@@ -142,7 +140,6 @@ class DEPHeapBypass(Signature):
 class DEPStackBypass(Signature):
     name = "dep_heap_bypass"
     description = "DEP was bypassed by marking part of the stack executable"
-    weight = 3
     severity = 3
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -158,7 +158,7 @@ class DEPHeapBypass(Signature):
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot in the following processes: "
+            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot in the processes: "
             list = ",".join(self.pname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -72,7 +72,7 @@ class ExploitHeapspray(Signature):
                      
         return self.has_marks()
         
-        # Copyright (C) 2015 Optiv, Inc. (brad.spengler@optiv.com), Updated 2016 for Cuckoo 2.0
+# Copyright (C) 2015 Optiv, Inc. (brad.spengler@optiv.com), Updated 2016 for Cuckoo 2.0
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -125,6 +125,44 @@ class StackPivot(Signature):
             self.description += list
         return self.has_marks()
 
+class DEPHeapBypass(Signature):
+    name = "dep_heap_bypass"
+    description = "DEP was bypassed by marking part of the heap executable following a stack pivot"
+    severity = 6
+    categories = ["exploit"]
+    authors = ["Optiv", "Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ignore = False
+        self.pname = []
+        if self.get_results("target", {}).get("category") == "file":
+            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
+                self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
+
+    def on_call(self, call, process):
+        if "stack_dep_bypass" in call["arguments"]:
+            if call["arguments"]["heap_dep_bypass"] == 1 and call["arguments"]["stack_pivoted"] == 1 and not self.ignore:
+                pname = process["process_name"]
+                if pname not in self.pname:
+                    self.pname.append(pname)
+                self.mark_call()
+
+    def on_complete(self):
+        if len(self.pname) == 1:
+            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot by the process "
+            for pname in self.pname:
+                self.description += pname
+        elif len(self.pname) > 1:
+            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot by the following processes: "
+            list = ",".join(self.pname )
+            self.description += list
+        return self.has_marks()
+
 class DEPStackBypass(Signature):
     name = "dep_stack_bypass"
     description = "DEP was bypassed by marking part of the stack executable"

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -121,7 +121,7 @@ class StackPivot(Signature):
                 self.description += pname
         elif len(self.pname) > 1:
             self.description = "Stack pivoting was detected when using a critical API by the processes "
-            list = ",".join(self.pname )
+            list = ", ".join(self.pname )
             self.description += list
         return self.has_marks()
 
@@ -159,7 +159,7 @@ class DEPHeapBypass(Signature):
                 self.description += pname
         elif len(self.pname) > 1:
             self.description = "DEP was bypassed by marking part of the heap executable by the processes "
-            list = ",".join(self.pname )
+            list = ", ".join(self.pname )
             self.description += list
         return self.has_marks()
 
@@ -197,6 +197,6 @@ class DEPStackBypass(Signature):
                 self.description += pname
         elif len(self.pname) > 1:
             self.description = "DEP was bypassed by marking part of the stack executable by the processes "
-            list = ",".join(self.pname )
+            list = ", ".join(self.pname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -116,11 +116,11 @@ class StackPivot(Signature):
 
     def on_complete(self):
         if len(self.pname) == 1:
-            self.description = "Stack pivoting was detected when using a critical API in the process "
+            self.description = "Stack pivoting was detected when using a critical API by the process "
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "Stack pivoting was detected when using a critical API in the processes "
+            self.description = "Stack pivoting was detected when using a critical API by the processes "
             list = ",".join(self.pname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -91,7 +91,7 @@ class StackPivot(Signature):
     name = "stack_pivot"
     description = "Stack pivoting was detected when using a critical API"
     severity = 6
-    categories = ["exploit"]
+    categories = ["exploit", "rop"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
     evented = True

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -249,6 +249,6 @@ class ShellcodeWriteProcessMemory(Signature):
                 self.description += pname
         elif len(self.scpname) > 1:
             self.description = "Found potential shellcode being written to a memory region previously marked executable following DEP bypass in the processes "
-            list = ",".join(self.scpname )
+            list = ", ".join(self.scpname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -203,7 +203,7 @@ class DEPStackBypass(Signature):
 
 class ShellcodeWriteProcessMemory(Signature):
     name = "shellcode_writeprocessmemory"
-    description = "Found potential shellcode being written to a memory region marked executable following DEP bypass"
+    description = "Found potential shellcode being written to a memory region previously marked executable following DEP bypass"
     severity = 3
     categories = ["exploit", "shellcode"]
     authors = ["Kevin Ross"]
@@ -244,11 +244,11 @@ class ShellcodeWriteProcessMemory(Signature):
 
     def on_complete(self):
         if len(self.scpname) == 1:
-            self.description = "Found potential shellcode being written to a memory region marked executable following DEP bypass in the process "
+            self.description = "Found potential shellcode being written to a memory region previously marked executable following DEP bypass in the process "
             for pname in self.scpname:
                 self.description += pname
         elif len(self.scpname) > 1:
-            self.description = "Found potential shellcode being written to a memory region marked executable following DEP bypass in the processes "
+            self.description = "Found potential shellcode being written to a memory region previously marked executable following DEP bypass in the processes "
             list = ",".join(self.scpname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -154,11 +154,11 @@ class DEPHeapBypass(Signature):
 
     def on_complete(self):
         if len(self.pname) == 1:
-            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot by the process "
+            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot in the process "
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot by the following processes: "
+            self.description = "DEP was bypassed by marking part of the heap executable following a stack pivot in the following processes: "
             list = ",".join(self.pname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -19,22 +19,24 @@ class ExploitHeapspray(Signature):
         self.prot = {}
 
     def on_call(self, call, process):
+        pname = process["process_name"]
         pid = call["arguments"]["process_identifier"]
         protection = call["arguments"]["protection"]
         alloc_type = call["arguments"]["allocation_type"]
         region_size = call["arguments"]["region_size"]
 
-        combo = pid, region_size, protection, alloc_type
+        combo = pname, pid, region_size, protection, alloc_type
         self.mem[combo] = self.mem.get(combo, 0) + 1
 
         self.prot[protection] = call["flags"].get("protection")
 
     def on_complete(self):
         for combo, count in self.mem.items():
-            pid, region_size, protection, alloc_type = combo
+            pname, pid, region_size, protection, alloc_type = combo
 
             if count >= 50:
                 self.mark(
+                    process=pname,
                     name="heapspray",
                     protection=self.prot.get(protection, protection),
                     count=count,

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -6,25 +6,23 @@ from lib.cuckoo.common.abstracts import Signature
 
 class ExploitHeapspray(Signature):
     name = "exploit_heapspray"
-    description = "A heapspray has been detected"
+    description = "A potential heapspray has been detected"
     severity = 3
     categories = ["exploit"]
-    authors = ["Cuckoo Technologies"]
+    authors = ["Cuckoo Technologies", "Kevin Ross"]
     minimum = "2.0"
+    references = ["https://www.corelan.be/index.php/2011/12/31/exploit-writing-tutorial-part-11-heap-spraying-demystified/"]
 
     filter_apinames = "NtAllocateVirtualMemory",
 
     def init(self):
         self.mem = {}
         self.prot = {}
+        self.heaptotals = dict()
         self.ignore = False
-        self.whitelist = ["PE32 executable"]
-        
         if self.get_results("target", {}).get("category") == "file":
-            filetype = self.get_results("target", {})["file"]["type"]
-            for ignore in self.whitelist:
-                if ignore in filetype:
-                    self.ignore = True
+            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
+                self.ignore = True
 
     def on_call(self, call, process):
         pname = process["process_name"]
@@ -46,7 +44,10 @@ class ExploitHeapspray(Signature):
 
                 if count >= 50:
                     written = int(region_size) * int(count)/1024/1024
-                    if written >= 20:
+                    if written >= 50:
+                        if pname not in self.heaptotals:
+                            self.heaptotals[pname] = 0
+                        self.heaptotals[pname] += written                    
                         self.mark(
                             process=pname,
                             name="heapspray",
@@ -56,4 +57,17 @@ class ExploitHeapspray(Signature):
                             total_mb=written,
                         )
 
+            if len(self.heaptotals) > 0:  
+                for pname, total in self.heaptotals.items():
+                    if "sprayed onto the heap of the" in self.description:
+                        self.description += " and %d megabytes onto the heap of the %s process" % (total, pname)
+                    else:
+                        self.description += ". %d megabytes was sprayed onto the heap of the %s process" % (total, pname)
+                    if total > 1024:
+                        self.severity = 6
+                    elif total > 512:
+                        self.severity = 5
+                    elif total > 256:
+                        self.severity = 4
+                     
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -146,7 +146,7 @@ class DEPHeapBypass(Signature):
 
     def on_call(self, call, process):
         if "heap_dep_bypass" in call["arguments"]:
-            if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore:
+            if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore and len(call["arguments"]["base_address"]) != 18:
                 pname = process["process_name"]
                 if pname not in self.pname:
                     self.pname.append(pname)

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -200,3 +200,55 @@ class DEPStackBypass(Signature):
             list = ", ".join(self.pname )
             self.description += list
         return self.has_marks()
+
+class ShellcodeWriteProcessMemory(Signature):
+    name = "shellcode_writeprocessmemory"
+    description = "Found potential shellcode being written to a memory region marked executable following DEP bypass"
+    severity = 3
+    categories = ["exploit", "shellcode"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ignore = False
+        self.exploit = 0
+        self.pname = []
+        self.scpname = []
+        self.memoryaddresses = []
+        if self.get_results("target", {}).get("category") == "file":
+            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
+                self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
+
+    def on_call(self, call, process):
+        if call["api"] == "WriteProcessMemory" and self.exploit and not self.ignore:
+            buf = call["arguments"]["buffer"]
+            pname = process["process_name"]
+            addr = call["arguments"]["base_address"]
+            if pname in self.pname and addr in self.memoryaddresses and len(buf) > 0:
+                self.scpname.append(pname)
+                self.mark_call()
+        
+        elif "stack_pivoted" in call["arguments"]:
+            if (call["arguments"]["stack_pivoted"] == 1 or call["arguments"]["stack_dep_bypass"] == 1 or call["arguments"]["heap_dep_bypass"] == 1) and not self.ignore:
+                pname = process["process_name"]
+                addr = call["arguments"]["base_address"]
+                if pname not in self.pname:
+                    self.pname.append(pname)
+                if addr not in self.memoryaddresses:
+                    self.memoryaddresses.append(addr)
+                self.exploit = 1
+
+    def on_complete(self):
+        if len(self.scpname) == 1:
+            self.description = "Found potential shellcode being written to a memory region marked executable following DEP bypass in the process "
+            for pname in self.scpname:
+                self.description += pname
+        elif len(self.scpname) > 1:
+            self.description = "Found potential shellcode being written to a memory region marked executable following DEP bypass in the processes "
+            list = ",".join(self.scpname )
+            self.description += list
+        return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -125,44 +125,6 @@ class StackPivot(Signature):
             self.description += list
         return self.has_marks()
 
-class DEPHeapBypass(Signature):
-    name = "dep_heap_bypass"
-    description = "DEP was bypassed by marking part of the heap executable"
-    severity = 3
-    categories = ["exploit"]
-    authors = ["Optiv", "Kevin Ross"]
-    minimum = "2.0"
-    evented = True
-
-    def __init__(self, *args, **kwargs):
-        Signature.__init__(self, *args, **kwargs)
-        self.ignore = False
-        self.pname = []
-        if self.get_results("target", {}).get("category") == "file":
-            if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
-                self.ignore = True
-
-    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
-
-    def on_call(self, call, process):
-        if "heap_dep_bypass" in call["arguments"]:
-            if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore:
-                pname = process["process_name"]
-                if pname not in self.pname:
-                    self.pname.append(pname)
-                self.mark_call()
-
-    def on_complete(self):
-        if len(self.pname) == 1:
-            self.description = "DEP was bypassed by marking part of the heap executable by the process "
-            for pname in self.pname:
-                self.description += pname
-        elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the heap executable by the processes "
-            list = ", ".join(self.pname )
-            self.description += list
-        return self.has_marks()
-
 class DEPStackBypass(Signature):
     name = "dep_stack_bypass"
     description = "DEP was bypassed by marking part of the stack executable"

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -146,7 +146,7 @@ class DEPHeapBypass(Signature):
 
     def on_call(self, call, process):
         if "heap_dep_bypass" in call["arguments"]:
-            if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore and len(call["arguments"]["base_address"]) != 18:
+            if call["arguments"]["heap_dep_bypass"] == 1 and not self.ignore:
                 pname = process["process_name"]
                 if pname not in self.pname:
                     self.pname.append(pname)


### PR DESCRIPTION
Hey, 

Thanks for this. I have been looking for a way to do a sig to detect heap sprays reliably :)

I have added in extracton of the process name to make it easier ot identify what is being exploited. It may also be useful to whitelist executable content so only things like browsers, PDF readers, office etc is covered which are more likely to actually be subject to heap sprays and also reduce FP chances. If it can be made that the package used it extracted on automatic submission too then something like it not being: self.results["info"]["package"] not in ["exe", "rar", "zip", "dll", "regsvr"]: could be used to do this.

On the exploit front I would like to convert the following but require changes if you wanted to further increase exploit detection :-D

- Stack Pivot (requires stuff from cuckoosploit. I see pull request submitted https://github.com/cuckoosandbox/monitor/pull/17): https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/stack_pivot.py
- DEP_Bypass (APIs in cuckoo 2.0 don't seem to show old protection): https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/dep_bypass.py
- DEP_Disable (requires NtSetInformationProcess; not sure if hooked already or not but I have not found a good exploit to test this with anyway): https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/dep_disable.py