### PR TITLE
Add in Dridex signature

### DIFF
--- a/modules/signatures/windows/dridex_apis.py
+++ b/modules/signatures/windows/dridex_apis.py
@@ -1,0 +1,173 @@
+# Copyright (C) 2015-2016 KillerInstinct, Updated 2016 for Cuckoo 2.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+try:
+    import re2 as re
+except ImportError:
+    import re
+
+from lib.cuckoo.common.abstracts import Signature
+
+class Dridex_APIs(Signature):
+    name = "dridex_behavior"
+    description = "Exhibits behavior characteristic of Dridex malware"
+    weight = 3
+    severity = 3
+    categories = ["banker", "trojan"]
+    families = ["dridex"]
+    authors = ["KillerInstinct"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.compname = ""
+        self.username = ""
+        self.is_xp = False
+        self.crypted = []
+        # Set to false if you don't want to extract c2 IPs
+        self.extract = True
+        self.sockmon = dict()
+        self.payloadip = dict()
+        self.decompMZ = False
+        self.ip_check = str()
+        self.port_check = str()
+        self.post_check = False
+        self.ret = False
+        self.isdridex = False
+        self.cncstart = False
+        self.whitelist_ports = ["80", "8080", "443", "8443"]
+
+    filter_apinames = set(["RegQueryValueExA", "CryptHashData", "connect", "send", "recv",
+                           "RtlDecompressBuffer", "InternetConnectW", "HttpOpenRequestW",
+                           "InternetCrackUrlA", "HttpSendRequestW"])
+
+    def on_call(self, call, process):
+        if call["api"] == "RegQueryValueExA":
+            # There are many more ways to get the computer name, this is the
+            # pattern observed with all Dridex varients 08/14 - 03/15 so far.
+            testkey = call["arguments"]["regkey"].lower()
+            if testkey == "hkey_local_machine\\system\\controlset001\\control\\computername\\computername\\computername":
+                buf = call["arguments"]["value"]
+                if buf:
+                    self.compname = buf.lower()
+                    self.mark_call()
+            if testkey == "hkey_current_user\\volatile environment\\username":
+                if call["status"]:
+                    buf = call["arguments"]["value"]
+                    if buf:
+                        self.username = buf.lower()
+                        self.mark_call()
+                else:
+                    self.is_xp = True
+
+        elif call["api"] == "CryptHashData":
+            buf = call["arguments"]["buffer"].lower()
+            self.crypted.append(buf)
+            if self.username in buf or self.compname in buf:
+                self.mark_call()
+
+        elif call["api"] == "connect":
+            if not self.extract:
+                return None
+
+            socknum = str(call["arguments"]["socket"])
+            if socknum and socknum not in self.sockmon.keys():
+                self.sockmon[socknum] = ""
+
+            lastip = call["arguments"]["ip"]
+            self.sockmon[socknum] = lastip
+
+        elif call["api"] == "send":
+            if not self.extract:
+                return None
+
+            socknum = str(call["arguments"]["socket"])
+            if socknum and socknum in self.sockmon.keys():
+                buf = call["arguments"]["buffer"]
+                # POST is a stable indicator observed so far
+                if buf and buf[:4] == "POST":
+                    self.payloadip["send"] = self.sockmon[socknum]
+                    self.mark_call()
+
+        elif call["api"] == "recv":
+            if not self.extract:
+                return None
+
+            socknum = str(call["arguments"]["socket"])
+            if socknum and socknum in self.sockmon.keys():
+                buf = call["arguments"]["buffer"]
+                if buf:
+                    clen = re.search(r"Content-Length:\s([^\s]+)", buf)
+                    if clen:
+                        length = int(clen.group(1))
+                        if length > 100000:
+                            if "send" in self.payloadip and self.sockmon[socknum] == self.payloadip["send"]:
+                                # Just a sanity check to make sure the IP hasn't changed
+                                # since this is a primitive send/recv monitor
+                                self.payloadip["recv"] = self.sockmon[socknum]
+                                self.mark_call()
+
+        elif call["api"] == "RtlDecompressBuffer":
+            buf = call["arguments"]["uncompressed_buffer"]
+            if buf.startswith("MZ"):
+                self.decompMZ = True
+                self.mark_call()
+
+        elif call["api"] == "InternetConnectW":
+            if self.decompMZ:
+                ip = call["arguments"]["hostname"]
+                if not any(char.isalpha() for char in ip):
+                    self.ip_check = ip
+                    self.port_check = str(call["arguments"]["port"])
+            elif call["arguments"]["port"] not in self.whitelist_ports:
+                self.cncstart = True
+                self.mark_call()
+
+        elif call["api"] == "HttpOpenRequestW":
+            if self.ip_check and self.port_check:
+                if call["arguments"]["http_method"] == "POST":
+                    self.post_check = True
+            elif self.cncstart:
+                self.mark_call()
+
+        elif call["api"] == "InternetCrackUrlA":
+            if self.post_check:
+                buf = call["arguments"]["url"]
+                if buf.lower().startswith("https") and self.port_check != "443":
+                    if buf.lower().split("/")[-1] == self.ip_check:
+                        self.isdridex = True
+                        self.mark_call()
+            elif self.cncstart:
+                self.mark_call()
+
+        elif call["api"] == "HttpSendRequestW" and self.cncstart:
+                self.mark_call()
+
+        return None
+
+    def on_complete(self):
+        if self.compname and (self.username or self.is_xp) and self.crypted:
+            buf = self.compname + self.username
+            for item in self.crypted:
+                if buf in item:
+                    self.isdridex = True
+
+        # TO BE FIXED UP. OLDER SAMPLES BUT WANT TO BRING INLINE WITH REST OF RESULTS MARKING API CALLS
+        #pattern = r".*\\CurrentVersion\\Explorer\\CLSID\\\{[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\}\\ShellFolder\\[0-9A-Fa-f]{8,24}"
+        #if self.check_key(pattern=pattern, regex=True, actions=["regkey_written"], all=True):
+        #    self.isdridex = True
+
+        if self.isdridex:
+            return self.has_marks()


### PR DESCRIPTION
Converted cuckoo-modified signature:
https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/dridex_apis.py

Some points:
- Should work across older and new dridex versions. However new Dridex versions using injection and I have noted this in my "cuckoo injection" issue that I raised as while the core behaviour is mostly the same overall Cuckoo 2.0 fails to follow this injection. This means the signature will be unable to work properly against newer versions due to this visbility loss.
- I removed all stuff about config decoding from the converted signature as not present (this is a completely seperate feature and does not affect overall detection).
- I have left in the network call stuff which would feed into the decoding as I want to mark that and also because it results in a True result for that flow which is another detection avenue. I have also added in some additional marking of network traffic around this as getting this done can reveal IPs, ports used and other useful information.
