### PR TITLE
Add in teslacrypt signature

### DIFF
--- a/modules/signatures/windows/ransomware_teslacrypt.py
+++ b/modules/signatures/windows/ransomware_teslacrypt.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2015-2016 KillerInstinct, Updated 2016 for Cuckoo 2.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import re2 as re
+except ImportError:
+    import re
+
+from lib.cuckoo.common.abstracts import Signature
+
+class Teslacrypt_APIs(Signature):
+    name = "teslacrypt_behavior"
+    description = "Exhibits behavior characteristic of Teslacrypt ransomware"
+    weight = 3
+    severity = 3
+    categories = ["ransomware"]
+    families = ["teslacrypt"]
+    authors = ["KillerInstinct"]
+    minimum = "2.0"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.extcount = 0
+        self.c2s = set()
+        self.uristruct = False
+        self.urivars = ["sub", "addr", "size", "version", "os", "id", "inst_id"]
+        self.pat = r"(?:https?:\/\/)?(?:[\da-z\.-]+)\.(?:[0-9a-z\.]{2,6})" \
+                   r"(?:\d{1,5})?(?:[\/\w\.-]*)\/?"
+
+    filter_apinames = set(["CryptDecrypt"])
+
+    def on_call(self, call, process):
+        if call["api"] == "CryptDecrypt":
+            buf = call["arguments"]["buffer"]
+            if buf:
+                if self.uristruct and re.match(self.pat, buf):
+                    self.c2s.add(buf.replace("\\x00", ""))
+                # Indicator to be used later
+                if buf.startswith(".") and len(buf) < 64:
+                    self.extcount += 1
+                # Parse for c2 structure
+                else:
+                    buf = buf.lower()
+                    if all(s in buf for s in self.urivars):
+                        self.uristruct = True
+
+    def on_complete(self):
+        ret = False
+        if self.uristruct or self.extcount > 150:
+            ret = True
+
+        if ret:
+            if self.c2s:
+                for c2 in self.c2s:
+                    self.mark_ioc("C2", c2)
+
+        return self.has_marks()


### PR DESCRIPTION
Up to you if you want this added as it is a now defunct ransomware following the criminal operators shutting up shop but here it is and able to id samples. It is a converted cuckoo-modified sig:

https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/alphacrypt_apis.py
