### PR TITLE
Added Word & Excel to whitelist in antisandbox_sleep.py

### DIFF
--- a/modules/signatures/windows/antisandbox_sleep.py
+++ b/modules/signatures/windows/antisandbox_sleep.py
@@ -30,6 +30,8 @@ class AntiSandboxSleep(Signature):
         "adobearm.exe",
         "iexplore.exe",
         "acrord32.exe",
+        "winword.exe",
+        "excel.exe",
     ]
 
     def init(self):


### PR DESCRIPTION
When analysing office documents, this rule systematically trips with a 120 seconds delay. Adding Word & Excel to the whitelist solve this issue.