### PR TITLE
Exploit sig: Change DLL sig to cover all the hooked APIs indicative of payload/she…

### DIFF
--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -26,20 +26,21 @@ class ExploitHeapspray(Signature):
 
     def on_call(self, call, process):
         pname = process["process_name"]
+        pid = call["arguments"].get("process_identifier")
         protection = call["arguments"]["protection"]
         alloc_type = call["arguments"]["allocation_type"]
         region_size = call["arguments"]["region_size"]
         allocation_typefull = call["flags"].get("allocation_type")
 
         if "MEM_COMMIT" in allocation_typefull:
-            combo = pname, region_size, protection, alloc_type
+            combo = pname, pid, region_size, protection, alloc_type
             self.mem[combo] = self.mem.get(combo, 0) + 1
             self.prot[protection] = call["flags"].get("protection")
 
     def on_complete(self):
         if not self.ignore:
             for combo, count in self.mem.items():
-                pname, region_size, protection, alloc_type = combo
+                pname, pid, region_size, protection, alloc_type = combo
 
                 if count >= 50:
                     written = int(region_size) * int(count)/1024/1024
@@ -105,8 +106,6 @@ class StackPivot(Signature):
 
     filter_apinames = critical_apinames
 
-    filter_apinames = critical_apinames
-
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.ignore = False
@@ -140,8 +139,6 @@ class DEPHeapBypass(Signature):
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
-
-    filter_apinames = critical_apinames
 
     filter_apinames = critical_apinames
 
@@ -181,8 +178,6 @@ class DEPStackBypass(Signature):
 
     filter_apinames = critical_apinames
 
-    filter_apinames = critical_apinames
-
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.ignore = False
@@ -216,8 +211,6 @@ class ShellcodeWriteProcessMemory(Signature):
     categories = ["exploit", "shellcode"]
     authors = ["Kevin Ross"]
     minimum = "2.0"
-
-    filter_apinames = critical_apinames
 
     filter_apinames = critical_apinames
 

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -68,7 +68,7 @@ class ExploitHeapspray(Signature):
                         self.severity = 5
                     elif total > 256:
                         self.severity = 4
-                     
+
         return self.has_marks()
         
 # Copyright (C) 2015 Optiv, Inc. (brad.spengler@optiv.com), Updated 2016 for Cuckoo 2.0

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -262,14 +262,14 @@ class ShellcodeWriteProcessMemory(Signature):
             self.description += ", ".join(self.scpname)
         return self.has_marks()
 
-class StackPivotDllLoad(Signature):
-    name = "stack_pivot_dll_load"
-    description = "DLLs were loaded following stack pivoting indicative of shellcode"
+class StackPivotShellcodeAPIs(Signature):
+    name = "stack_pivot_shellcode_apis"
+    description = "API calls following stack pivoting indicative of shellcode execution have been detected"
     severity = 3
     categories = ["exploit", "rop", "shellcode"]
     authors = ["Kevin Ross"]
     minimum = "2.0"
-
+    evented = True
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.ignore = False
@@ -278,7 +278,7 @@ class StackPivotDllLoad(Signature):
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
 
-    filter_apinames = "LdrLoadDll",
+    filter_apinames = set(["LdrLoadDll","LdrGetDllHandle","URLDownloadToFileW","CreateProcessInternalW","NtCreateProcess","NtCreateProcessEx","NtCreateUserProcess","RtlCreateUserProcess"])
 
     def on_call(self, call, process):
         if "stack_pivoted" in call["arguments"]:
@@ -290,10 +290,11 @@ class StackPivotDllLoad(Signature):
 
     def on_complete(self):
         if len(self.pname) == 1:
-            self.description = "DLLs were loaded following stack pivoting indicative of shellcode in the process "
+            self.description = "API calls following stack pivoting indicative of shellcode execution have been detected in the process "
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DLLs were loaded following stack pivoting indicative of shellcode in the processes "
-            self.description += ", ".join(self.pname)
+            self.description = "API calls following stack pivoting indicative of shellcode execution have been detected in the processes "
+            list = ", ".join(self.pname )
+            self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -26,28 +26,27 @@ class ExploitHeapspray(Signature):
 
     def on_call(self, call, process):
         pname = process["process_name"]
-        pid = call["arguments"]["process_identifier"]
         protection = call["arguments"]["protection"]
         alloc_type = call["arguments"]["allocation_type"]
         region_size = call["arguments"]["region_size"]
         allocation_typefull = call["flags"].get("allocation_type")
 
         if "MEM_COMMIT" in allocation_typefull:
-            combo = pname, pid, region_size, protection, alloc_type
+            combo = pname, region_size, protection, alloc_type
             self.mem[combo] = self.mem.get(combo, 0) + 1
             self.prot[protection] = call["flags"].get("protection")
 
     def on_complete(self):
         if not self.ignore:
             for combo, count in self.mem.items():
-                pname, pid, region_size, protection, alloc_type = combo
+                pname, region_size, protection, alloc_type = combo
 
                 if count >= 50:
                     written = int(region_size) * int(count)/1024/1024
                     if written >= 50:
                         if pname not in self.heaptotals:
                             self.heaptotals[pname] = 0
-                        self.heaptotals[pname] += written
+                        self.heaptotals[pname] += written                    
                         self.mark(
                             process=pname,
                             name="heapspray",
@@ -57,7 +56,7 @@ class ExploitHeapspray(Signature):
                             total_mb=written,
                         )
 
-            if self.heaptotals:
+            if len(self.heaptotals) > 0:  
                 for pname, total in self.heaptotals.items():
                     if "sprayed onto the heap of the" in self.description:
                         self.description += " and %d megabytes onto the heap of the %s process" % (total, pname)
@@ -69,9 +68,9 @@ class ExploitHeapspray(Signature):
                         self.severity = 5
                     elif total > 256:
                         self.severity = 4
-
+                     
         return self.has_marks()
-
+        
 # Copyright (C) 2015 Optiv, Inc. (brad.spengler@optiv.com), Updated 2016 for Cuckoo 2.0
 #
 # This program is free software: you can redistribute it and/or modify
@@ -87,15 +86,6 @@ class ExploitHeapspray(Signature):
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-critical_apinames = [
-    "NtAllocateVirtualMemory",
-    "NtProtectVirtualMemory",
-    "VirtualProtectEx",
-    "NtWriteVirtualMemory",
-    "NtWow64WriteVirtualMemory64",
-    "WriteProcessMemory",
-]
-
 class StackPivot(Signature):
     name = "stack_pivot"
     description = "Stack pivoting was detected when using a critical API"
@@ -103,10 +93,7 @@ class StackPivot(Signature):
     categories = ["exploit", "rop"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
-
-    filter_apinames = critical_apinames
-
-    filter_apinames = critical_apinames
+    evented = True
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -115,6 +102,8 @@ class StackPivot(Signature):
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
         if "stack_pivoted" in call["arguments"]:
@@ -131,7 +120,8 @@ class StackPivot(Signature):
                 self.description += pname
         elif len(self.pname) > 1:
             self.description = "Stack pivoting was detected when using a critical API by the processes "
-            self.description += ", ".join(self.pname)
+            list = ", ".join(self.pname )
+            self.description += list
         return self.has_marks()
 
 class DEPHeapBypass(Signature):
@@ -141,10 +131,7 @@ class DEPHeapBypass(Signature):
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
-
-    filter_apinames = critical_apinames
-
-    filter_apinames = critical_apinames
+    evented = True
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -153,6 +140,8 @@ class DEPHeapBypass(Signature):
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
         if "stack_dep_bypass" in call["arguments"]:
@@ -168,8 +157,9 @@ class DEPHeapBypass(Signature):
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the heap executable by the processes "
-            self.description += ", ".join(self.pname)
+            self.description = "DEP was bypassed by marking part of the heap executable following stack pivoting in the processes: "
+            list = ",".join(self.pname )
+            self.description += list
         return self.has_marks()
 
 class DEPStackBypass(Signature):
@@ -179,10 +169,7 @@ class DEPStackBypass(Signature):
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
-
-    filter_apinames = critical_apinames
-
-    filter_apinames = critical_apinames
+    evented = True
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -191,6 +178,8 @@ class DEPStackBypass(Signature):
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
+
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
         if "stack_dep_bypass" in call["arguments"]:
@@ -207,7 +196,8 @@ class DEPStackBypass(Signature):
                 self.description += pname
         elif len(self.pname) > 1:
             self.description = "DEP was bypassed by marking part of the stack executable by the processes "
-            self.description += ", ".join(self.pname)
+            list = ", ".join(self.pname )
+            self.description += list
         return self.has_marks()
 
 class ShellcodeWriteProcessMemory(Signature):
@@ -217,10 +207,7 @@ class ShellcodeWriteProcessMemory(Signature):
     categories = ["exploit", "shellcode"]
     authors = ["Kevin Ross"]
     minimum = "2.0"
-
-    filter_apinames = critical_apinames
-
-    filter_apinames = critical_apinames
+    evented = True
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -233,6 +220,8 @@ class ShellcodeWriteProcessMemory(Signature):
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
 
+    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
+
     def on_call(self, call, process):
         if call["api"] == "WriteProcessMemory" and self.exploit and not self.ignore:
             buf = call["arguments"]["buffer"]
@@ -241,7 +230,7 @@ class ShellcodeWriteProcessMemory(Signature):
             if pname in self.pname and addr in self.memoryaddresses and len(buf) > 0:
                 self.scpname.append(pname)
                 self.mark_call()
-
+        
         elif "stack_pivoted" in call["arguments"]:
             if (call["arguments"]["stack_pivoted"] == 1 or call["arguments"]["stack_dep_bypass"] == 1 or call["arguments"]["heap_dep_bypass"] == 1) and not self.ignore:
                 pname = process["process_name"]
@@ -259,12 +248,13 @@ class ShellcodeWriteProcessMemory(Signature):
                 self.description += pname
         elif len(self.scpname) > 1:
             self.description = "Found potential shellcode being written to a memory region previously marked executable following DEP bypass in the processes "
-            self.description += ", ".join(self.scpname)
+            list = ", ".join(self.scpname )
+            self.description += list
         return self.has_marks()
 
 class StackPivotShellcodeAPIs(Signature):
     name = "stack_pivot_shellcode_apis"
-    description = "API calls following stack pivoting indicative of shellcode execution have been detected"
+    description = "API calls following stack pivoting indicative of shellcode have been detected"
     severity = 3
     categories = ["exploit", "rop", "shellcode"]
     authors = ["Kevin Ross"]
@@ -278,11 +268,8 @@ class StackPivotShellcodeAPIs(Signature):
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
 
-    filter_apinames = [
-        "LdrLoadDll", "LdrGetDllHandle", "URLDownloadToFileW", "CreateProcessInternalW", "NtCreateProcess", 
-        "NtCreateProcessEx", "NtCreateUserProcess", "RtlCreateUserProcess",
-    ]
-    
+    filter_apinames = set(["LdrLoadDll","LdrGetDllHandle","URLDownloadToFileW","CreateProcessInternalW","NtCreateProcess","NtCreateProcessEx","NtCreateUserProcess","RtlCreateUserProcess"])
+
     def on_call(self, call, process):
         if "stack_pivoted" in call["arguments"]:
             if call["arguments"]["stack_pivoted"] == 1 and not self.ignore:
@@ -293,11 +280,11 @@ class StackPivotShellcodeAPIs(Signature):
 
     def on_complete(self):
         if len(self.pname) == 1:
-            self.description = "API calls following stack pivoting indicative of shellcode execution have been detected in the process "
+            self.description = "API calls following stack pivoting indicative of shellcode have been detected in the process "
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "API calls following stack pivoting indicative of shellcode execution have been detected in the processes "
+            self.description = "API calls following stack pivoting indicative of shellcode have been detected in the processes "
             list = ", ".join(self.pname )
             self.description += list
         return self.has_marks()

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -46,7 +46,7 @@ class ExploitHeapspray(Signature):
                     if written >= 50:
                         if pname not in self.heaptotals:
                             self.heaptotals[pname] = 0
-                        self.heaptotals[pname] += written                    
+                        self.heaptotals[pname] += written
                         self.mark(
                             process=pname,
                             name="heapspray",

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -278,8 +278,11 @@ class StackPivotShellcodeAPIs(Signature):
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
 
-    filter_apinames = set(["LdrLoadDll","LdrGetDllHandle","URLDownloadToFileW","CreateProcessInternalW","NtCreateProcess","NtCreateProcessEx","NtCreateUserProcess","RtlCreateUserProcess"])
-
+    filter_apinames = [
+        "LdrLoadDll", "LdrGetDllHandle", "URLDownloadToFileW", "CreateProcessInternalW", "NtCreateProcess", 
+        "NtCreateProcessEx", "NtCreateUserProcess", "RtlCreateUserProcess",
+    ]
+    
     def on_call(self, call, process):
         if "stack_pivoted" in call["arguments"]:
             if call["arguments"]["stack_pivoted"] == 1 and not self.ignore:

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -56,7 +56,7 @@ class ExploitHeapspray(Signature):
                             total_mb=written,
                         )
 
-            if len(self.heaptotals) > 0:  
+            if self.heaptotals:
                 for pname, total in self.heaptotals.items():
                     if "sprayed onto the heap of the" in self.description:
                         self.description += " and %d megabytes onto the heap of the %s process" % (total, pname)
@@ -70,7 +70,7 @@ class ExploitHeapspray(Signature):
                         self.severity = 4
 
         return self.has_marks()
-        
+
 # Copyright (C) 2015 Optiv, Inc. (brad.spengler@optiv.com), Updated 2016 for Cuckoo 2.0
 #
 # This program is free software: you can redistribute it and/or modify
@@ -86,6 +86,15 @@ class ExploitHeapspray(Signature):
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+critical_apinames = [
+    "NtAllocateVirtualMemory",
+    "NtProtectVirtualMemory",
+    "VirtualProtectEx",
+    "NtWriteVirtualMemory",
+    "NtWow64WriteVirtualMemory64",
+    "WriteProcessMemory",
+]
+
 class StackPivot(Signature):
     name = "stack_pivot"
     description = "Stack pivoting was detected when using a critical API"
@@ -93,7 +102,10 @@ class StackPivot(Signature):
     categories = ["exploit", "rop"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
-    evented = True
+
+    filter_apinames = critical_apinames
+
+    filter_apinames = critical_apinames
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -102,8 +114,6 @@ class StackPivot(Signature):
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
-
-    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
         if "stack_pivoted" in call["arguments"]:
@@ -120,8 +130,7 @@ class StackPivot(Signature):
                 self.description += pname
         elif len(self.pname) > 1:
             self.description = "Stack pivoting was detected when using a critical API by the processes "
-            list = ", ".join(self.pname )
-            self.description += list
+            self.description += ", ".join(self.pname)
         return self.has_marks()
 
 class DEPHeapBypass(Signature):
@@ -131,7 +140,10 @@ class DEPHeapBypass(Signature):
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
-    evented = True
+
+    filter_apinames = critical_apinames
+
+    filter_apinames = critical_apinames
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -140,8 +152,6 @@ class DEPHeapBypass(Signature):
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
-
-    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
         if "stack_dep_bypass" in call["arguments"]:
@@ -157,9 +167,8 @@ class DEPHeapBypass(Signature):
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "DEP was bypassed by marking part of the heap executable following stack pivoting in the processes: "
-            list = ",".join(self.pname )
-            self.description += list
+            self.description = "DEP was bypassed by marking part of the heap executable by the processes "
+            self.description += ", ".join(self.pname)
         return self.has_marks()
 
 class DEPStackBypass(Signature):
@@ -169,7 +178,10 @@ class DEPStackBypass(Signature):
     categories = ["exploit"]
     authors = ["Optiv", "Kevin Ross"]
     minimum = "2.0"
-    evented = True
+
+    filter_apinames = critical_apinames
+
+    filter_apinames = critical_apinames
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -178,8 +190,6 @@ class DEPStackBypass(Signature):
         if self.get_results("target", {}).get("category") == "file":
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
-
-    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
 
     def on_call(self, call, process):
         if "stack_dep_bypass" in call["arguments"]:
@@ -196,8 +206,7 @@ class DEPStackBypass(Signature):
                 self.description += pname
         elif len(self.pname) > 1:
             self.description = "DEP was bypassed by marking part of the stack executable by the processes "
-            list = ", ".join(self.pname )
-            self.description += list
+            self.description += ", ".join(self.pname)
         return self.has_marks()
 
 class ShellcodeWriteProcessMemory(Signature):
@@ -207,7 +216,10 @@ class ShellcodeWriteProcessMemory(Signature):
     categories = ["exploit", "shellcode"]
     authors = ["Kevin Ross"]
     minimum = "2.0"
-    evented = True
+
+    filter_apinames = critical_apinames
+
+    filter_apinames = critical_apinames
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -220,8 +232,6 @@ class ShellcodeWriteProcessMemory(Signature):
             if "PE32 executable" in self.get_results("target", {})["file"]["type"]:
                 self.ignore = True
 
-    filter_apinames = set(["NtAllocateVirtualMemory", "NtProtectVirtualMemory", "VirtualProtectEx", "NtWriteVirtualMemory", "NtWow64WriteVirtualMemory64", "WriteProcessMemory"])
-
     def on_call(self, call, process):
         if call["api"] == "WriteProcessMemory" and self.exploit and not self.ignore:
             buf = call["arguments"]["buffer"]
@@ -230,7 +240,7 @@ class ShellcodeWriteProcessMemory(Signature):
             if pname in self.pname and addr in self.memoryaddresses and len(buf) > 0:
                 self.scpname.append(pname)
                 self.mark_call()
-        
+
         elif "stack_pivoted" in call["arguments"]:
             if (call["arguments"]["stack_pivoted"] == 1 or call["arguments"]["stack_dep_bypass"] == 1 or call["arguments"]["heap_dep_bypass"] == 1) and not self.ignore:
                 pname = process["process_name"]
@@ -248,13 +258,12 @@ class ShellcodeWriteProcessMemory(Signature):
                 self.description += pname
         elif len(self.scpname) > 1:
             self.description = "Found potential shellcode being written to a memory region previously marked executable following DEP bypass in the processes "
-            list = ", ".join(self.scpname )
-            self.description += list
+            self.description += ", ".join(self.scpname)
         return self.has_marks()
 
 class StackPivotShellcodeAPIs(Signature):
     name = "stack_pivot_shellcode_apis"
-    description = "API calls following stack pivoting indicative of shellcode have been detected"
+    description = "API calls following stack pivoting indicative of shellcode execution have been detected"
     severity = 3
     categories = ["exploit", "rop", "shellcode"]
     authors = ["Kevin Ross"]
@@ -280,11 +289,11 @@ class StackPivotShellcodeAPIs(Signature):
 
     def on_complete(self):
         if len(self.pname) == 1:
-            self.description = "API calls following stack pivoting indicative of shellcode have been detected in the process "
+            self.description = "API calls following stack pivoting indicative of shellcode execution have been detected in the process "
             for pname in self.pname:
                 self.description += pname
         elif len(self.pname) > 1:
-            self.description = "API calls following stack pivoting indicative of shellcode have been detected in the processes "
+            self.description = "API calls following stack pivoting indicative of shellcode execution have been detected in the processes "
             list = ", ".join(self.pname )
             self.description += list
         return self.has_marks()


### PR DESCRIPTION
…llcode

Think I have got all the stack pivot sigs marked for shellcode/payload execution (the rest are those used for the actual pivoting and covered in other signatures).