### PR TITLE
Add in signature for modifying boot configuration

### DIFF
--- a/modules/signatures/windows/bootconfig_modify.py
+++ b/modules/signatures/windows/bootconfig_modify.py
@@ -30,7 +30,7 @@ class ModifiesBootConfig(Signature):
             buf = call["arguments"]["command_line"].lower()
         else:
             buf = call["arguments"]["filepath"].lower()
-        if "bcdedit" in buf:
+        if "bcdedit" in buf and "set" in buf:
             self.mark_ioc("command", buf)
 
     def on_complete(self):

--- a/modules/signatures/windows/bootconfig_modify.py
+++ b/modules/signatures/windows/bootconfig_modify.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ModifiesBootConfig(Signature):
+    name = "modifies_boot_config"
+    description = "Modifies boot configuration settings"
+    severity = 3
+    categories = ["persistance", "ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    filter_apinames = "ShellExecuteExW", "CreateProcessInternalW",
+
+    def on_call(self, call, process):
+        if call["api"] == "CreateProcessInternalW":
+            buf = call["arguments"]["command_line"].lower()
+        else:
+            buf = call["arguments"]["filepath"].lower()
+        if "bcdedit" in buf:
+            self.mark_ioc("command", buf)
+
+    def on_complete(self):
+        return self.has_marks()


### PR DESCRIPTION
This is this signature I had written https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/bcdedit_command.py but I did not direct conver this. However the bcdedit command does not appear in the processes like the process/commands so I had to get it through the API. 

This behavior can be seen the H1N1 sample mentioned here http://blogs.cisco.com/security/protecting-against-the-latest-variant-of-h1n1 (md5 22fbf0bf25e78043d35231852373df62). 

More analysis of H1N1 here:
http://blogs.cisco.com/security/h1n1-technical-analysis-reveals-new-capabilities
http://blogs.cisco.com/security/h1n1-technical-analysis-reveals-new-capabilities-part-2

I was also going to convert https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/h1n1_apis.py but the NtCreateEvent API is not hooked.
