### PR TITLE
Create signature for network traffic for injection

### DIFF
--- a/modules/signatures/windows/injection_network_traffic.py
+++ b/modules/signatures/windows/injection_network_traffic.py
@@ -47,14 +47,15 @@ class InjectionNetworkTraffic(Signature):
 
     def on_call(self, call, process):
         pname = process["process_name"].lower()
+        host = ""
         if pname in self.proc_list:
             if "ip_address" in call["arguments"]:
                 host = call["arguments"]["ip_address"]
             elif "hostname" in call["arguments"]:
                 host = call["arguments"]["hostname"]
 
-            if host:
-                if not host.startswith("127.") and not host.startswith("10.") and not host.startswith("172.16.") and not host.startswith("192.168."):
+            if host != "":
+                if not host.startswith(("127.", "10.", "172.16.", "192.168.")):
                     if pname not in self.pname:
                         self.pname.append(pname)
                     self.mark_call()

--- a/modules/signatures/windows/injection_network_traffic.py
+++ b/modules/signatures/windows/injection_network_traffic.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2016 Kevin Ross
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class InjectionNetworkTraffic(Signature):
+    name = "injection_network_trafic"
+    description = "A system process is connecting to the network likely as a result of code injection"
+    severity = 3
+    categories = ["injection", "cnc"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.pname = []
+
+    proc_list = [
+        "csrss.exe",
+        "explorer.exe",
+        "lsass.exe", 
+        "services.exe", 
+        "smss.exe", 
+        "userinit.exe", 
+        "wininit.exe", 
+        "winlogon.exe", 
+    ]
+
+    filter_apinames = "InternetCrackUrlW", "InternetCrackUrlA", "URLDownloadToFileW", "URLDownloadToCacheFileW", "HttpOpenRequestW", "WSASend", "send", "sendto", "connect",
+
+    def on_call(self, call, process):
+        pname = process["process_name"].lower()
+        if pname in self.proc_list:
+            if pname not in self.pname:
+                self.pname.append(pname)
+            self.mark_call()
+
+    def on_complete(self):
+        if len(self.pname) == 1:
+            self.description = "Network communications from a system process indicative of possible code injection originated from the process "
+            for pname in self.pname:
+                self.description += pname
+        elif len(self.pname) > 1:
+            self.description = "Network communications from a system process indicative of possible code injection originated from the processes "
+            self.description += ", ".join(self.pname)
+        return self.has_marks()

--- a/modules/signatures/windows/injection_network_traffic.py
+++ b/modules/signatures/windows/injection_network_traffic.py
@@ -16,7 +16,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class InjectionNetworkTraffic(Signature):
     name = "injection_network_trafic"
-    description = "A system process is connecting to the network likely as a result of code injection"
+    description = "A system process is connecting to the network likely as a result of process injection"
     severity = 3
     categories = ["injection", "cnc", "stealth"]
     authors = ["Kevin Ross"]


### PR DESCRIPTION
This is a signature I am testing about system processes appearing in the process tree and generating network traffic which is possibly from code injection and seems to be the case in my testing. I also intend to do one with these appearing in the processes but not as a child process again indicative of injection without having to detect the injection itself.
