### PR TITLE
Create rule for process memory dump yara hit

### DIFF
--- a/modules/signatures/windows/memdump_yara.py
+++ b/modules/signatures/windows/memdump_yara.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class ProcMemDumpYara(Signature):
     name = "memdump_yara"
-    description = "Yara rule detection in process memory"
+    description = "Yara rule detected in process memory"
     severity = 2
     categories = ["generic"]
     authors = ["Kevin Ross", "KillerInstinct"]

--- a/modules/signatures/windows/memdump_yara.py
+++ b/modules/signatures/windows/memdump_yara.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2016 Kevin Ross, KillerInstinct
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ProcMemDumpYara(Signature):
+    name = "memdump_yara"
+    description = "Yara rule detection in process memory"
+    severity = 2
+    categories = ["generic"]
+    authors = ["Kevin Ross", "KillerInstinct"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        for procmem in self.get_results("procmemory", []):
+            for yara in procmem.get("yara", []):
+                yararule = yara["name"]
+                ruledescription = yara["meta"]["description"]
+                self.mark(
+                    rule=yararule,
+                    description=ruledescription,                      
+                )
+
+        return self.has_marks()

--- a/modules/signatures/windows/memdump_yara.py
+++ b/modules/signatures/windows/memdump_yara.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 Kevin Ross, KillerInstinct
+# Copyright (C) 2016 Kevin Ross
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,8 +20,12 @@ class ProcMemDumpYara(Signature):
     description = "Yara rule detected in process memory"
     severity = 2
     categories = ["generic"]
-    authors = ["Kevin Ross", "KillerInstinct"]
+    authors = ["Kevin Ross"]
     minimum = "2.0"
+
+    malicious_rules = [
+    "Ransomware_Message",
+    ]
 
     def on_complete(self):
         for procmem in self.get_results("procmemory", []):
@@ -32,5 +36,7 @@ class ProcMemDumpYara(Signature):
                     rule=yararule,
                     description=ruledescription,                      
                 )
+                if yararule in self.malicious_rules:
+                    self.severity = 3
 
         return self.has_marks()


### PR DESCRIPTION
Created a rule to detect yara signature hits for process memory. Never actually used the cuckoo-modified signature to create this but as one exists & as I may use concepts from it in the future I have credited author too as concept is same. modified signature here:

https://github.com/spender-sandbox/community-modified/blob/master/modules/signatures/procmem_yara.py
