### PR TITLE
Create signature for PDF static analysis

### DIFF
--- a/modules/signatures/cross/static_pdf.py
+++ b/modules/signatures/cross/static_pdf.py
@@ -25,5 +25,5 @@ class PDFJavaScript(Signature):
 
     def on_complete(self):
         for pdf in self.get_results("static", {}).get("pdf", []):
-            if "javascript" in pdf:
+            if "javascript" in pdf and len(pdf["javascript"]) > 0:
                 return True

--- a/modules/signatures/cross/static_pdf.py
+++ b/modules/signatures/cross/static_pdf.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2016 Kevin Ross.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class PDFJavaScript(Signature):
+    name = "pdf_javascript"
+    description = "The PDF file contains JavaScript code"
+    severity = 2
+    categories = ["static"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        for pdf in self.get_results("static", {}).get("pdf", []):
+            if "javascript" in pdf:
+                return True


### PR DESCRIPTION
Added in signature to take advantage of peepdf although only JavaScript seems to currently seems there for features but will add more as things are added/I get detections in test although I did not have libemu on this system so I will sort that out. Is it the case that more peepdf stuff will be reported on (CVE, XFA extraction which is common in more recent exploits, suspicious features etc)?

Thanks.
