### PR TITLE
Create a signature for displaying HTA files

### DIFF
--- a/modules/signatures/windows/displays_hta.py
+++ b/modules/signatures/windows/displays_hta.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2017 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class DisplaysHTA(Signature):
+    name = "displays_hta"
+    description = "Displays a HTA file to the user common in ransomware"
+    severity = 2
+    categories = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        for cmdline in self.get_command_lines():
+            lower = cmdline.lower()
+
+            if "mshta" in lower:
+                self.mark(cmdline=cmdline)
+
+        return self.has_marks()


### PR DESCRIPTION
This signature is to identify cases where mainly ransomware displays a HTA file to the user and can be useful in identifying ransomware message files being shown.