### PR TITLE
persistance_ads.py: Zone.Identifier ADS severity ponderation

### DIFF
--- a/modules/signatures/windows/persistence_ads.py
+++ b/modules/signatures/windows/persistence_ads.py
@@ -28,7 +28,7 @@ class ADS(Signature):
             parts = filepath.replace("/", "\\").split("\\")
             if ":" in parts[-1]:
                 self.mark_ioc("file", filepath)
-                if parts[-1].split(":")[1] == "Zone.Identifier":
+                if parts[-1].split(":")[-1] == "Zone.Identifier":
                     self.description = "Creates a Zone.Identifier Alternate Data Stream (ADS)"
                     self.severity = 1
 

--- a/modules/signatures/windows/persistence_ads.py
+++ b/modules/signatures/windows/persistence_ads.py
@@ -28,5 +28,8 @@ class ADS(Signature):
             parts = filepath.replace("/", "\\").split("\\")
             if ":" in parts[-1]:
                 self.mark_ioc("file", filepath)
-                
+                if parts[-1].split(":")[1] == "Zone.Identifier":
+                    self.description = "Creates a Zone.Identifier Alternate Data Stream (ADS)"
+                    self.severity = 1
+
         return self.has_marks()


### PR DESCRIPTION
It's quite common for the ADS "Zone.Identifier" to be written by Windows when cuckoo uploads a sample for analysis.
As such, this event should still be logged, but it's less likely to be malicious, hence the proposed severity = 1