### PR TITLE
Remove term "infected" from installs TOR message

### DIFF
--- a/modules/signatures/windows/network_tor.py
+++ b/modules/signatures/windows/network_tor.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class Tor(Signature):
     name = "network_tor"
-    description = "Installs Tor on the infected machine"
+    description = "Installs Tor on the machine"
     severity = 3
     categories = ["network", "anonimity", "tor"]
     authors = ["nex"]


### PR DESCRIPTION
This is really just nitpicking but the term "infected" suggests that the program is 100% malware and the machine is already infected with something but say I was to install torbrowser package the computer isn't infected.