### PR TITLE
Persistence_ADS: Fix & ponderation

### DIFF
--- a/modules/signatures/windows/persistence_ads.py
+++ b/modules/signatures/windows/persistence_ads.py
@@ -27,6 +27,11 @@ class ADS(Signature):
         for filepath in self.get_files():
             parts = filepath.replace("/", "\\").split("\\")
             if ":" in parts[-1]:
-                self.mark_ioc("file", filepath)
+                if len(parts[-1].split(":")[-1]) > 0:
+                    self.mark_ioc("file", filepath)
+                if parts[-1].split(":")[-1] == "Zone.Identifier":
+                    self.severity=0
+                    self.description="Creates a Zone.Identifier Alternate Data Stream (ADS)"
+
                 
         return self.has_marks()


### PR DESCRIPTION
False positive fix - Fixes the case where access to a drive (eg: Z:) was incorrectly interpreted as access to an ADS
Zone.Identifier ADS severity ponderation: this ADS is commonly generated by Windows for most files.