### PR TITLE
Create signature for creating a suspended process

### DIFF
--- a/modules/signatures/windows/injection_createsuspended.py
+++ b/modules/signatures/windows/injection_createsuspended.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2017 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class InjectionCreateSuspended(Signature):
+    name = "injection_create_suspended"
+    description = "Created a process in a suspended state common in code injection or process hollowing"
+    severity = 3
+    categories = ["injection"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+    evented = True
+
+    filter_apinames = [
+        "CreateProcessInternalW"
+    ]
+
+    def on_call(self, call, process):
+        if call["arguments"]["creation_flags"] == 4:
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()

--- a/modules/signatures/windows/injection_createsuspended.py
+++ b/modules/signatures/windows/injection_createsuspended.py
@@ -19,17 +19,17 @@ class InjectionCreateSuspended(Signature):
     name = "injection_create_suspended"
     description = "Created a process in a suspended state common in code injection or process hollowing"
     severity = 3
-    categories = ["injection"]
+    categories = ["injection", "unpacking"]
     authors = ["Kevin Ross"]
     minimum = "2.0"
     evented = True
 
     filter_apinames = [
-        "CreateProcessInternalW"
+        "CreateProcessInternalW",
     ]
 
     def on_call(self, call, process):
-        if call["arguments"]["creation_flags"] == 4:
+        if "CREATE_SUSPENDED" in call["flags"]["creation_flags"]:
             self.mark_call()
 
     def on_complete(self):


### PR DESCRIPTION
While many times the unpacking signature covers this some samples like below does not fire. Still creating a process with the create suspended flag is a dead giveaway of process hollowing and this should help to bring up the "malware score" of the sample.

Sample; Family: Smokeloader MD5: 7bd631b8c5a03eb5676c6dff243d632a