### PR TITLE
False Negative fix for Windows Utilities

### DIFF
--- a/modules/signatures/windows/windows_utilities.py
+++ b/modules/signatures/windows/windows_utilities.py
@@ -17,9 +17,12 @@ class UsesWindowsUtilities(Signature):
         "at ",
         "at.exe",
         "attrib",
-        "del",
-        "dir",
-        "erase",
+        "del ",
+        "del.exe",
+        "dir ",
+        "dir.exe",
+        "erase ",
+        "erase.exe",
         "fsutil",
         "getmac",
         "ipconfig",
@@ -27,7 +30,8 @@ class UsesWindowsUtilities(Signature):
         "net.exe",
         "netsh",
         "netstat",
-        "ping",
+        "ping ",
+        "ping.exe",
         "qwinsta",
         "reg ",
         "reg.exe",
@@ -50,7 +54,7 @@ class UsesWindowsUtilities(Signature):
     def on_complete(self):
         for cmdline in self.get_command_lines():
             for utility in self.utilities:
-                if cmdline.lower().startswith(utility):
+                if utility in cmdline.lower():
                     self.mark_ioc("cmdline", cmdline)
 
         return self.has_marks()
@@ -102,7 +106,7 @@ class SuspiciousCommandTools(Signature):
     def on_complete(self):
         for cmdline in self.get_command_lines():
             for utility in self.utilities:
-                if cmdline.lower().startswith(utility):
+                if utility in cmdline.lower():
                     self.mark_ioc("cmdline", cmdline)
 
         return self.has_marks()


### PR DESCRIPTION
I have found that using startswith results sometimes in a false negative if the command line starts with a path i.e C:\Windows\system32\netsh.exe advfirewall reset seen in cerber. I have put it back to utility in cmdline to fix this and to try and avoid false positives I have had to use syntax on some commands of "command " and "command.exe" where the change of the term appearing in an unrelated command is possible.