### PR TITLE
Create signature for explorer Shell_TrayWnd injection code technique

### DIFF
--- a/modules/signatures/windows/injection_explorer.py
+++ b/modules/signatures/windows/injection_explorer.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2017 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class InjectionExplorer(Signature):
+    name = "injection_explorer"
+    description = "Performs code injection into Explorer process using the Shell_TrayWnd technique"
+    severity = 3
+    categories = ["Kevin Ross"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+    references = ["www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"]
+
+    filter_apinames = [
+        "Process32NextW",
+        "FindWindowW",
+        "SendNotifyMessageA",
+    ]
+
+    explorerpids = []
+    windowhandle = ""
+    injected = False
+
+    def on_call(self, call, process):
+        if call["api"] == "Process32NextW":
+            if call["arguments"]["process_name"] == "explorer.exe":
+                self.explorerpids.append(call["arguments"]["process_identifier"])
+                self.mark_call()
+
+        elif call["api"] == "FindWindowW":
+            if call["arguments"]["class_name"] == "Shell_TrayWnd":
+                self.windowhandle = call["return_value"]
+                self.mark_call()
+
+        elif call["api"] == "SendNotifyMessageA":
+            if call["arguments"]["process_identifier"] in self.explorerpids and int(call["arguments"]["window_handle"], 16) == self.windowhandle:
+            
+                self.injected = True
+                self.mark_call()
+
+    def on_complete(self):
+        if self.injected:
+            return self.has_marks()

--- a/modules/signatures/windows/injection_explorer.py
+++ b/modules/signatures/windows/injection_explorer.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class InjectionExplorer(Signature):
     name = "injection_explorer"
-    description = "Performs code injection into Explorer process using the Shell_TrayWnd technique"
+    description = "Performs code injection into the Explorer process using the Shell_TrayWnd technique"
     severity = 3
     categories = ["injection"]
     authors = ["Kevin Ross"]

--- a/modules/signatures/windows/injection_explorer.py
+++ b/modules/signatures/windows/injection_explorer.py
@@ -19,7 +19,7 @@ class InjectionExplorer(Signature):
     name = "injection_explorer"
     description = "Performs code injection into Explorer process using the Shell_TrayWnd technique"
     severity = 3
-    categories = ["Kevin Ross"]
+    categories = ["injection"]
     authors = ["Kevin Ross"]
     minimum = "2.0"
     references = ["www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"]

--- a/modules/signatures/windows/injection_explorer.py
+++ b/modules/signatures/windows/injection_explorer.py
@@ -47,7 +47,6 @@ class InjectionExplorer(Signature):
 
         elif call["api"] == "SendNotifyMessageA":
             if call["arguments"]["process_identifier"] in self.explorerpids and int(call["arguments"]["window_handle"], 16) == self.windowhandle:
-            
                 self.injected = True
                 self.mark_call()
 


### PR DESCRIPTION
Add sig to cover this. You can get an excellent overview and analysis here of this and other code injection techniques https://www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process. 

This was tested on powerloader MD5 7de3350cafbe8fe843aea9e8564e6af5. However there is a few issues:

- GetWindowLong & more importantly SetWindowLong is not hooked. SetWindowLong is a key part of this technique so if the hook could be added it would be great to detect each stage https://msdn.microsoft.com/en-us/library/windows/desktop/ms633591%28v=vs.85%29.aspx. However with the unique values in sig and the method of identifying explorer pid, checking Shell_TrayWnd called which is key stage too and pretty unique and then checking SendNotifyMessageA goes to explorer to the  Shell_TrayWnd window it should never false positive and hopefully false negative.

- I have raised this as an issue but you will see in test once explorer.exe has been injected while you can still see traffic (malware traffic sig fires for me and you can get IDS alerts for explorer.exe traffic) cuckoo 2.0 fails to follow the injection. Cuckoo-modified follows it sucessfully if you want to see more of the behaviour.