### PR TITLE
Change deletes self sig name to deletes executed

### DIFF
--- a/modules/signatures/windows/deletes_executed.py
+++ b/modules/signatures/windows/deletes_executed.py
@@ -15,9 +15,9 @@
 
 from lib.cuckoo.common.abstracts import Signature
 
-class DeletesSelf(Signature):
-    name = "deletes_self"
-    description = "Deletes its original binary from disk"
+class DeletesExecutedFiles(Signature):
+    name = "deletes_executed_files"
+    description = "Deletes executed files from disk"
     severity = 3
     categories = ["persistence", "stealth"]
     authors = ["Optiv", "Kevin Ross"]


### PR DESCRIPTION
I have changed this sig name to detect deletion of any executed files from disk which could highlight stealth cleanup. Deleting original EXE is extremely malicious and could be another sig but the sig did not match the original process accurately and in its current form that is being used is not just the original file but any executed file being deleted hence the name change