### PR TITLE
Create sig for writing EXE (and generic code sig) to memory of another process

### DIFF
--- a/modules/signatures/windows/injection_writemem_exe.py
+++ b/modules/signatures/windows/injection_writemem_exe.py
@@ -24,6 +24,7 @@ class InjectionWriteMemoryEXE(Signature):
     minimum = "2.0"
 
     filter_apinames = [
+        "NtWriteVirtualmemory",
         "WriteProcessMemory",
     ]
 

--- a/modules/signatures/windows/injection_writemem_exe.py
+++ b/modules/signatures/windows/injection_writemem_exe.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2017 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class InjectionWriteMemoryEXE(Signature):
+    name = "injection_write_memory_exe"
+    description = "Writes an executable/dll to the memory of another process"
+    severity = 3
+    categories = ["injection", "unpacking"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    filter_apinames = [
+        "WriteProcessMemory",
+    ]
+
+    def on_call(self, call, process):
+        if call["api"] == "WriteProcessMemory":
+            if call["arguments"]["buffer"].startswith("MZ") and not call["arguments"]["process_handle"].startswith("0xfffffff"):
+                self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()

--- a/modules/signatures/windows/injection_writemem_exe.py
+++ b/modules/signatures/windows/injection_writemem_exe.py
@@ -29,9 +29,8 @@ class InjectionWriteMemoryEXE(Signature):
     ]
 
     def on_call(self, call, process):
-        if call["api"] == "WriteProcessMemory":
-            if call["arguments"]["buffer"].startswith("MZ") and not call["arguments"]["process_handle"].startswith("0xfffffff"):
-                self.mark_call()
+        if call["arguments"]["buffer"].startswith("MZ") and not call["arguments"]["process_handle"].startswith("0xfffffff"):
+            self.mark_call()
 
     def on_complete(self):
         return self.has_marks()

--- a/modules/signatures/windows/injection_writememory.py
+++ b/modules/signatures/windows/injection_writememory.py
@@ -15,9 +15,29 @@
 
 from lib.cuckoo.common.abstracts import Signature
 
+class InjectionWriteMemory(Signature):
+    name = "injection_write_memory"
+    description = "Potential code injection by writing to the memory of another process"
+    severity = 2
+    categories = ["injection"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    filter_apinames = [
+        "NtWriteVirtualmemory",
+        "WriteProcessMemory",
+    ]
+
+    def on_call(self, call, process):
+        if len(call["arguments"]["buffer"]) > 0 and not call["arguments"]["process_handle"].startswith("0xfffffff"):
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()
+
 class InjectionWriteMemoryEXE(Signature):
     name = "injection_write_memory_exe"
-    description = "Writes an executable/dll to the memory of another process"
+    description = "Code injection by writing an executable/dll to the memory of another process"
     severity = 3
     categories = ["injection", "unpacking"]
     authors = ["Kevin Ross"]

--- a/modules/signatures/windows/injection_writememory.py
+++ b/modules/signatures/windows/injection_writememory.py
@@ -37,7 +37,7 @@ class InjectionWriteMemory(Signature):
 
 class InjectionWriteMemoryEXE(Signature):
     name = "injection_write_memory_exe"
-    description = "Code injection by writing an executable/dll to the memory of another process"
+    description = "Code injection by writing an executable or DLL to the memory of another process"
     severity = 3
     categories = ["injection", "unpacking"]
     authors = ["Kevin Ross"]

--- a/modules/signatures/windows/injection_writememory.py
+++ b/modules/signatures/windows/injection_writememory.py
@@ -18,7 +18,7 @@ from lib.cuckoo.common.abstracts import Signature
 class InjectionWriteMemory(Signature):
     name = "injection_write_memory"
     description = "Potential code injection by writing to the memory of another process"
-    severity = 2
+    severity = 3
     categories = ["injection"]
     authors = ["Kevin Ross"]
     minimum = "2.0"


### PR DESCRIPTION
Seen in Dridex MD5 2eaf243bad4b1c22089e7654524f0e5a