### PR TITLE
Add in signature for IRMA scan results

### DIFF
--- a/modules/signatures/windows/antivirus_irma.py
+++ b/modules/signatures/windows/antivirus_irma.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2017 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class AntiVirusIRMA(Signature):
+    name = "antivirus_irma"
+    description = "File has been identified by at least one AntiVirus scanned by IRMA as malicious"
+    severity = 3
+    categories = ["antivirus"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        results = self.get_results("irma", [])
+        if results.get("probe_results"):
+            results = results.get("probe_results")
+            for result in results:
+                engine = result["name"]
+                verdict = result["results"]
+                if verdict:
+                    self.mark_ioc(engine, verdict)                    
+
+        return self.has_marks()

--- a/modules/signatures/windows/antivirus_irma.py
+++ b/modules/signatures/windows/antivirus_irma.py
@@ -24,13 +24,14 @@ class AntiVirusIRMA(Signature):
     minimum = "2.0"
 
     def on_complete(self):
-        results = self.get_results("irma", [])
-        if results.get("probe_results"):
-            results = results.get("probe_results")
-            for result in results:
-                engine = result["name"]
-                verdict = result["results"]
-                if verdict:
-                    self.mark_ioc(engine, verdict)                    
+        if self.get_results("irma", []):
+            results = self.get_results("irma", [])
+            if results.get("probe_results"):
+                results = results.get("probe_results")
+                for result in results:
+                    engine = result["name"]
+                    verdict = result["results"]
+                    if verdict:
+                        self.mark_ioc(engine, verdict)                    
 
         return self.has_marks()

--- a/modules/signatures/windows/antivirus_irma.py
+++ b/modules/signatures/windows/antivirus_irma.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class AntiVirusIRMA(Signature):
     name = "antivirus_irma"
-    description = "File has been identified by at least one AntiVirus scanned by IRMA as malicious"
+    description = "File has been identified by at least one AntiVirus engine on IRMA as malicious"
     severity = 3
     categories = ["antivirus"]
     authors = ["Kevin Ross"]


### PR DESCRIPTION
This is a basic sig I have written for IRMA scan results and probably can do with some more work but it does work it seems. I "trust" the scan results a lot more than virustotal in this case as people may have fewer scanners so we go severity 3 from the first alert and I don't bother with counting up each one as there may only be a handful of AVs so no point counting up results to adjust severity like VirusTotal sig.

On another note if AV scanning done on every file regardless of OS shouldn't this and antivirus_virustotal.py be in cross instead of Windows folder?