### PR TITLE
Add in signature for enumrating directories

### DIFF
--- a/modules/signatures/windows/enumerates_directories.py
+++ b/modules/signatures/windows/enumerates_directories.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2017 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class EnumeratesDirectories(Signature):
+    name = "enumerates_directories"
+    description = "Enumerates a large number of directories possibly to identify files for later use or modification"
+    severity = 2
+    categories = ["recon", "ransomware", "infostealer"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        for directory in self.get_files(actions=["directory_enumerated"]):
+            self.mark_ioc("directory", directory)
+
+        return self.has_marks(50)


### PR DESCRIPTION
Often seen in infostealers and especially ransomware.