### PR TITLE
Add in txt/html/htm extension requirement for ransomware messages

### DIFF
--- a/modules/signatures/windows/ransomware_message.py
+++ b/modules/signatures/windows/ransomware_message.py
@@ -26,7 +26,7 @@ class RansomwareMessage(Signature):
     severity = 3
     categories = ["ransomware"]
     authors = ["Kevin Ross"]
-    minimum = "2.0"
+    minimum = "2.0.4"
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -115,7 +115,7 @@ class RansomwareMessage(Signature):
     def on_call(self, call, process):
         if process["process_name"].lower() not in self.whitelistprocs:
             buff = call["arguments"]["buffer"].lower()
-            if len(buff) >= 128:
+            if len(buff) >= 128 and (call["arguments"]["filepath"].endswith(".txt") or call["arguments"]["filepath"].endswith(".html")):
                 patterns = "|".join(self.indicators)
                 if len(re.findall(patterns, buff)) > 1:
                     self.mark_call()

--- a/modules/signatures/windows/ransomware_message.py
+++ b/modules/signatures/windows/ransomware_message.py
@@ -115,7 +115,7 @@ class RansomwareMessage(Signature):
     def on_call(self, call, process):
         if process["process_name"].lower() not in self.whitelistprocs:
             buff = call["arguments"]["buffer"].lower()
-            if len(buff) >= 128 and (call["arguments"]["filepath"].endswith(".txt") or call["arguments"]["filepath"].endswith(".html")):
+            if len(buff) >= 128 and (call["arguments"]["filepath"].endswith(".txt") or call["arguments"]["filepath"].endswith(".htm") or call["arguments"]["filepath"].endswith(".html")):
                 patterns = "|".join(self.indicators)
                 if len(re.findall(patterns, buff)) > 1:
                     self.mark_call()


### PR DESCRIPTION
Using filepath added in latest monitor check file being written is .txt or .html extension which helps to reduce false positives (and maybe increases performance as you aren't moving onto the next step as often for checking the lists)