### PR TITLE
Checks if any command line call is equal to the deleted file, not only the first one

### DIFF
--- a/modules/signatures/windows/deletes_self.py
+++ b/modules/signatures/windows/deletes_self.py
@@ -32,7 +32,7 @@ class DeletesSelf(Signature):
 
         if processes:
             for deletedfile in self.get_files(actions=["file_deleted"]):
-                if deletedfile in processes[0]:
+                if deletedfile in processes:
                     self.mark_ioc("file", deletedfile)
 
         return self.has_marks()


### PR DESCRIPTION
Currently the signature only checks if the first command_line entry of the report is equal to one of the deleted files. In case of more than one command line calls the position of the matching call in the report cannot be predicted, therefore it has to be checked if any of the calls is equal to one of the deleted files.