### PR TITLE
Completely replace thread injection signature

### DIFF
--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -88,7 +88,7 @@ class ResumeThread(Signature):
         if process["pid"] != injected_pid:
             self.mark_ioc(
                 "Process injection",
-                "Process %s resumed thread in remote process %s" % (process["pid"],
+                "Process %s resumed a thread in remote process %s" % (process["pid"],
                                                                injected_pid)
             )
             self.mark_call()

--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -95,3 +95,30 @@ class ResumeThread(Signature):
 
     def on_complete(self):
         return self.has_marks()
+
+class NtSetContextThreadRemote(Signature):
+    name = "injection_ntsetcontextthread"
+    description = "Used NtSetContextThread to potentially modify a thread in a remote process indicative of process injection"
+    severity = 3
+    categories = ["injection", "shellcode"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+    references = ["www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"]
+
+
+    filter_apinames = [
+        "NtSetContextThread",
+    ]
+
+    def on_call(self, call, process):
+        injected_pid = call["arguments"]["process_identifier"]
+        if process["pid"] != injected_pid:
+            self.mark_ioc(
+                "Process injection",
+                "Process %s called NtSetContextThread to modify thread in remote process %s" % (process["pid"],
+                                                               injected_pid)
+            )
+            self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()

--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -98,7 +98,7 @@ class ResumeThread(Signature):
 
 class NtSetContextThreadRemote(Signature):
     name = "injection_ntsetcontextthread"
-    description = "Used NtSetContextThread to potentially modify a thread in a remote process indicative of process injection"
+    description = "Used NtSetContextThread to modify a thread in a remote process indicative of process injection"
     severity = 3
     categories = ["injection", "shellcode"]
     authors = ["Kevin Ross"]

--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -46,7 +46,7 @@ class InjectionCreateRemoteThread(Signature):
 
 class InjectionQueueApcThread(Signature):
     name = "injection_queueapcthread"
-    description = "Creates a thread using NtQueueApcThread in a remote process potentially indicative of code injection"
+    description = "Creates a thread using NtQueueApcThread in a remote process potentially indicative of process injection"
     severity = 3
     categories = ["injection"]
     authors = ["Kevin Ross"]
@@ -72,7 +72,7 @@ class InjectionQueueApcThread(Signature):
 
 class ResumeThread(Signature):
     name = "injection_resumethread"
-    description = "Resumed a suspended thread in a remote process potentially indicative of code injection"
+    description = "Resumed a suspended thread in a remote process potentially indicative of process injection"
     severity = 3
     categories = ["injection"]
     authors = ["Kevin Ross"]

--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class InjectionCreateRemoteThread(Signature):
     name = "injection_createremotethread"
-    description = "Creates a thread using CreateRemoteThread in a non-child process indicative of code injection"
+    description = "Creates a thread using CreateRemoteThread in a non-child process indicative of process injection"
     severity = 3
     categories = ["injection"]
     authors = ["Kevin Ross"]

--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012 JoseMi "h0rm1" Holguin (@j0sm1)
+# Copyright (C) 2017 Kevin Ross
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,46 +15,57 @@
 
 from lib.cuckoo.common.abstracts import Signature
 
-class InjectionThread(Signature):
-    """Instead of overly complicated, and easily bypassable, handle tracking
-    we're just looking at the functions that have been used in each process.
-    If a subset containing the majority of the functions required for creating
-    a remote thread have been used then we trigger this signature."""
-
-    name = "injection_thread"
-    description = "Code injection with CreateRemoteThread or NtQueueApcThread in a remote process"
+class InjectionCreateRemoteThread(Signature):
+    name = "injection_createremotethread"
+    description = "Creates a thread using CreateRemoteThread in a non-child process indicative of code injection"
     severity = 3
     categories = ["injection"]
-    authors = ["JoseMi Holguin", "nex", "Accuvant"]
+    authors = ["Kevin Ross"]
     minimum = "2.0"
+    references = ["www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"]
 
     filter_apinames = [
-        "NtOpenProcess",
-        "NtMapViewOfSection",
-        "NtAllocateVirtualMemory",
-        "NtWriteVirtualMemory",
         "CreateRemoteThread",
         "CreateRemoteThreadEx",
+    ]
+
+    def on_call(self, call, process):
+        if call["arguments"]["process_handle"] != "0xffffffff" and call["arguments"]["process_handle"] != "0xffffffffffffffff":
+            injected_pid = call["arguments"]["process_identifier"]
+            call_process = self.get_process_by_pid(injected_pid)
+            if not call_process or call_process["ppid"] != process["pid"]:
+                self.mark_ioc(
+                    "Process injection",
+                    "Process %s created a remote thread in non-child process %s" % (process["pid"],
+                                                               injected_pid)
+                )
+                self.mark_call()
+
+    def on_complete(self):
+        return self.has_marks()
+
+class InjectionQueueApcThread(Signature):
+    name = "injection_queueapcthread"
+    description = "Creates a thread using NtQueueApcThread in a remote process potentially indicative of code injection"
+    severity = 3
+    categories = ["injection"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+    references = ["www.endgame.com/blog/technical-blog/ten-process-injection-techniques-technical-survey-common-and-trending-process"]
+
+    filter_apinames = [
         "NtQueueApcThread",
     ]
 
-    def init(self):
-        self.functions = {}
-
-    def on_process(self, process):
-        self.functions[process["pid"]] = set()
-
     def on_call(self, call, process):
-        # We're not interested in events to the local process. TODO Is there a
-        # better way to identify the current process?
-        process_handle = call["arguments"].get("process_handle")
-        if process_handle and process_handle.startswith("0xffffffff"):
-            return
-
-        self.functions[process["pid"]].add(call["api"])
-        self.mark_call()
+        injected_pid = call["arguments"]["process_identifier"]
+        if process["pid"] != injected_pid:
+            self.mark_ioc(
+                "Process injection",
+                "Process %s created a thread in remote process %s" % (process["pid"],
+                                                               injected_pid)
+            )
+            self.mark_call()
 
     def on_complete(self):
-        for pid, functions in self.functions.items():
-            if len(functions) >= len(self.filter_apinames)-3:
-                return True
+        return self.has_marks()


### PR DESCRIPTION
The current CreateRemoteThread type signature seems to never detect code injection. I have been writing various signatures (in other pull requests) and while these signatures are still experimental they highlight code injection sequences and anomalies without description end to end each process i.e must have this and that. For instance manipulating memory of a non-child process is its own signature, writing into other processes etc.

Now for this one I opted for 2 signatures. First is the CreateRemoteThread signature which tries to find non-child process injection and the other being QueueApcThread technique which cannot be non-child process so i basically did if it is doing this to another process. Currently the existing signature cannot match this properly because it relies on the handle not being 0xFFFFFFFF but this API does not have that anyway. This may cause FPs but so far so good.

Now as I said these signatures are experimental and I am not sure if the child process stuff is properly behaving how I hope but they seem to do well together in highlighting all kinds of process manipulation and injection so they are on their way.

Also it is worth noting other APIs if not hooked should be looked at for threat manipulation include:

- SetThreadContext
- SuspendThread
- CreateToolhelp32Snapshot
- Thread32First
- OpenThread

There are probably others too but it would be interesting if flagging manipulating thread of another process could be highlighted; I am not sure how this will work though given sometimes it is more threads that are covered in the APIs making it hard to work out which process it is manipulating but generally messing with threads or memory of another process is a sign of injection 