### PR TITLE
Add in signatures for adding user

### DIFF
--- a/modules/signatures/windows/windows_utilities.py
+++ b/modules/signatures/windows/windows_utilities.py
@@ -160,3 +160,33 @@ class CommandObfuscation(Signature):
                         self.mark_ioc("cmdline", cmdline)
 
         return self.has_marks()
+
+class AddsUser(Signature):
+    name = "adds_user"
+    description = "Uses windows command to add a user to the system"
+    severity = 2
+    categories = ["commands"]
+    authors = ["Kevin"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        for cmdline in self.get_command_lines():
+                if cmdline.lower().startswith("net") and "user /add" in cmdline.lower():
+                    self.mark_ioc("cmdline", cmdline)
+
+        return self.has_marks()
+
+class AddsUserAdmin(Signature):
+    name = "adds_user_admin"
+    description = "Uses windows command to add a user to the administrator group"
+    severity = 3
+    categories = ["commands"]
+    authors = ["Kevin"]
+    minimum = "2.0"
+
+    def on_complete(self):
+        for cmdline in self.get_command_lines():
+                if cmdline.lower().startswith("net") and "localgroup administrators" in cmdline.lower():
+                    self.mark_ioc("cmdline", cmdline)
+
+        return self.has_marks()

--- a/modules/signatures/windows/windows_utilities.py
+++ b/modules/signatures/windows/windows_utilities.py
@@ -110,57 +110,6 @@ class SuspiciousCommandTools(Signature):
 
         return self.has_marks()
 
-class LongCommandLine(Signature):
-    name = "long_command_line"
-    description = "A suspiciously long command line or script command was executed"
-    severity = 2
-    categories = ["commands"]
-    authors = ["Kevin Ross"]
-    minimum = "2.0"
-
-    utilities = [
-        "cmd",
-        "cscript",
-        "hta",
-        "powershell",
-        "wscript",
-    ]
-
-    def on_complete(self):
-        for cmdline in self.get_command_lines():
-            for utility in self.utilities:
-                if cmdline.lower().startswith(utility) and len(cmdline) > 150:
-                    self.mark_ioc("cmdline", cmdline)
-
-        return self.has_marks()
-
-class CommandObfuscation(Signature):
-    name = "command_obfuscation"
-    description = "A command line or script command was executed containing high entropy indicative of obfuscation"
-    severity = 2
-    categories = ["commands"]
-    authors = ["Kevin Ross"]
-    minimum = "2.0"
-
-    utilities = [
-        "cmd.exe",
-        "cmd ",
-        "cscript",
-        "hta.exe",
-        "hta ",
-        "powershell",
-        "wscript",
-    ]
-
-    def on_complete(self):
-        for cmdline in self.get_command_lines():
-            for utility in self.utilities:
-                if cmdline.lower().startswith(utility):
-                    if entropy.shannon_entropy(cmdline) > 0.56:
-                        self.mark_ioc("cmdline", cmdline)
-
-        return self.has_marks()
-
 class AddsUser(Signature):
     name = "adds_user"
     description = "Uses windows command to add a user to the system"

--- a/modules/signatures/windows/windows_utilities.py
+++ b/modules/signatures/windows/windows_utilities.py
@@ -2,6 +2,9 @@
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
 
+# This requires python entropy package to be installed with "pip install entropy"
+import entropy
+
 from lib.cuckoo.common.abstracts import Signature
 
 class UsesWindowsUtilities(Signature):
@@ -104,5 +107,56 @@ class SuspiciousCommandTools(Signature):
             for utility in self.utilities:
                 if cmdline.lower().startswith(utility):
                     self.mark_ioc("cmdline", cmdline)
+
+        return self.has_marks()
+
+class LongCommandLine(Signature):
+    name = "long_command_line"
+    description = "A suspiciously long command line or script command was executed"
+    severity = 2
+    categories = ["commands"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    utilities = [
+        "cmd",
+        "cscript",
+        "hta",
+        "powershell",
+        "wscript",
+    ]
+
+    def on_complete(self):
+        for cmdline in self.get_command_lines():
+            for utility in self.utilities:
+                if cmdline.lower().startswith(utility) and len(cmdline) > 150:
+                    self.mark_ioc("cmdline", cmdline)
+
+        return self.has_marks()
+
+class CommandObfuscation(Signature):
+    name = "command_obfuscation"
+    description = "A command line or script command was executed containing high entropy indicative of obfuscation"
+    severity = 3
+    categories = ["commands"]
+    authors = ["Kevin Ross"]
+    minimum = "2.0"
+
+    utilities = [
+        "cmd.exe",
+        "cmd ",
+        "cscript",
+        "hta.exe",
+        "hta ",
+        "powershell",
+        "wscript",
+    ]
+
+    def on_complete(self):
+        for cmdline in self.get_command_lines():
+            for utility in self.utilities:
+                if cmdline.lower().startswith(utility):
+                    if entropy.shannon_entropy(cmdline) > 0.56:
+                        self.mark_ioc("cmdline", cmdline)
 
         return self.has_marks()

--- a/modules/signatures/windows/windows_utilities.py
+++ b/modules/signatures/windows/windows_utilities.py
@@ -137,7 +137,7 @@ class LongCommandLine(Signature):
 class CommandObfuscation(Signature):
     name = "command_obfuscation"
     description = "A command line or script command was executed containing high entropy indicative of obfuscation"
-    severity = 3
+    severity = 2
     categories = ["commands"]
     authors = ["Kevin Ross"]
     minimum = "2.0"


### PR DESCRIPTION
For the command obfuscation signature it requires the python entropy package "pip install entropy". I have not handled for this not being present so either this is a requirement or this gets handled to ensure it is installed as I use this to calculate the general entropy of the command line to help find obfuscation.