### PR TITLE
Fix #378 AttributeError in creates_service.py

### DIFF
--- a/modules/signatures/windows/creates_service.py
+++ b/modules/signatures/windows/creates_service.py
@@ -23,7 +23,7 @@ class CreatesService(Signature):
         self.startedservices = []
 
     def on_call(self, call, process):
-        service_name = call["arguments"].get("service_name", "").lower()
+        service_name = (call["arguments"].get("service_name") or "").lower()
         if call["api"] == "CreateServiceA" or call["api"] == "CreateServiceW":
             self.services.append(service_name)
             self.mark_call()


### PR DESCRIPTION
In case that `call["arguments"].get("service_name", "")` yields None
e.g. `call = {"arguments": {"service_name": None}}`

~~~
Traceback (most recent call last):
  File "cuckoo/cuckoo/core/plugins.py", line 417, in call_signature
    if not signature.matched and handler(*args, **kwargs):
  File "cuckoo_data/signatures/windows/creates_service.py", line 26, in on_call
    service_name = call["arguments"].get("service_name", "").lower()
AttributeError: 'NoneType' object has no attribute 'lower'
~~~