### PR TITLE
NtWriteVirtualMemory not NtWriteVirtualmemory

### DIFF
--- a/modules/signatures/windows/injection_runpe.py
+++ b/modules/signatures/windows/injection_runpe.py
@@ -33,7 +33,7 @@ class InjectionRunPE(Signature):
         "NtAllocateVirtualMemory",
         "NtGetContextThread",
         "WriteProcessMemory",
-        "NtWriteVirtualmemory",
+        "NtWriteVirtualMemory",
         "NtMapViewOfSection",
         "NtSetContextThread",
         "NtResumeThread",


### PR DESCRIPTION
It looks like API names are compared [case sensitively](https://github.com/cuckoosandbox/cuckoo/blob/master/cuckoo/core/plugins.py#L435) - if that is the case (docs didn't seem to say much) then this string ought to be [`NtWriteVirtualMemory`](https://github.com/reactos/reactos/blob/c2c66aff7dacc62d125f2cd61d1167e9a2aa3fd6/sdk/include/ndk/mmfuncs.h#L313). As it's not documented, the reactos reimplementation is the best reference I can offer :)

I don't have an example of something this fixes or catches, just caught my eye when reading the code. Didn't check to see if other signatures are similarly afflicted. @jbremer looks to have added this and other APIs to this signature, albeit around three years ago, if this jogs any memory?