### PR TITLE
Remove non-child in createthread sig

### DIFF
--- a/modules/signatures/windows/injection_thread.py
+++ b/modules/signatures/windows/injection_thread.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class InjectionCreateRemoteThread(Signature):
     name = "injection_createremotethread"
-    description = "Creates a thread using CreateRemoteThread in a non-child process indicative of process injection"
+    description = "Creates a thread using CreateRemoteThread in a remote process indicative of process injection"
     severity = 3
     categories = ["injection"]
     authors = ["Kevin Ross"]
@@ -36,7 +36,7 @@ class InjectionCreateRemoteThread(Signature):
             if not call_process or call_process["ppid"] != process["pid"] and process["pid"] != injected_pid:
                 self.mark_ioc(
                     "Process injection",
-                    "Process %s created a remote thread in non-child process %s" % (process["pid"],
+                    "Process %s created a remote thread in remote process %s" % (process["pid"],
                                                                injected_pid)
                 )
                 self.mark_call()


### PR DESCRIPTION
Same as before. Non-child process changed to "remote" as this is more accurate to what the signature is doing