### PR TITLE
Fixed js_eval.py to support VBScript hooking

### DIFF
--- a/modules/signatures/cross/js_eval.py
+++ b/modules/signatures/cross/js_eval.py
@@ -18,6 +18,9 @@ class EvalJS(Signature):
         if call["arguments"]["type"] == "eval code":
             self.severity = 3
             self.description = "Executed javascript and unpacks itself"
+		
+        if "VBScript" in call["arguments"]["type"]:
+            self.description = "Executes VBScript"
 
         self.mark_call()
         return True


### PR DESCRIPTION
Previously js_eval.py simply reported 'Executed javascript' for any COleScript::Compile hook result, but since the VBScript hooking refers to the same function name this incorrectly identifies the language. Added check for VB content.