### PR TITLE
Update antivirus_irma.py

### DIFF
--- a/modules/signatures/windows/antivirus_irma.py
+++ b/modules/signatures/windows/antivirus_irma.py
@@ -30,8 +30,9 @@ class AntiVirusIRMA(Signature):
                 results = results.get("probe_results")
                 for result in results:
                     engine = result["name"]
-                    verdict = result["results"]
-                    if verdict:
-                        self.mark_ioc(engine, verdict)
+                    if result.get("results"):
+                        verdict = result["results"]
+                        if verdict:
+                            self.mark_ioc(engine, verdict)
 
         return self.has_marks()


### PR DESCRIPTION
Some IRMA probes in 'report.json' may contain filed "status" with value equal to "-1".
Json chunk containing "status":-1 does not contain "resuts" field (other chunks with different status value contains "result" field)
This leads to the following error:

```
Failed to run 'on_complete' of the antivirus_irma signature
Traceback (most recent call last):
  File "/opt/cuckoo/venv/local/lib/python2.7/site-packages/cuckoo/core/plugins.py", line 414, in call_signature
    if not signature.matched and handler(*args, **kwargs):
  File "/opt/cuckoo/data/signatures/windows/antivirus_irma.py", line 33, in on_complete
    verdict = result["results"]
KeyError: 'results'
```

Some kind of check or exception handling is required here