### PR TITLE
Verify if there is an initial process from target

### DIFF
--- a/modules/signatures/windows/moves_self.py
+++ b/modules/signatures/windows/moves_self.py
@@ -18,9 +18,12 @@ class MovesSelf(Signature):
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
-        self.initial_process = self.get_results("target", {}).get("file", {}).get("name", [])
+        self.initial_process = self.get_results("target", {}).get("file", {}).get("name", "")
 
     def on_call(self, call, process):
+        if not self.initial_process:
+            return
+
         oldpath = call["arguments"]["oldfilepath"]
         if self.initial_process in oldpath:
             self.mark_call()


### PR DESCRIPTION
Without verification, it raises an exception during URL analysis, as there
is not a target file in that case.