### PR TITLE
Add PowerPoint and Publisher to sleep signature whitelist

### DIFF
--- a/modules/signatures/windows/antisandbox_sleep.py
+++ b/modules/signatures/windows/antisandbox_sleep.py
@@ -32,6 +32,8 @@ class AntiSandboxSleep(Signature):
         "acrord32.exe",
         "winword.exe",
         "excel.exe",
+        "powerpnt.exe",
+        "mspub.exe",
     ]
 
     def init(self):


### PR DESCRIPTION
PowerPoint and Publisher similarly to Word and Excel cause false positives with
the sleep signature. Add them to the exclude list.