### PR TITLE
Memdump_urls.py use cwd whitelist

### DIFF
--- a/modules/signatures/windows/memdump_urls.py
+++ b/modules/signatures/windows/memdump_urls.py
@@ -1,9 +1,6 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
-from cuckoo.misc import cwd
-import os
-from urlparse import urlsplit
 
 try:
     import re2 as re
@@ -11,6 +8,8 @@ except ImportError:
     import re
 
 from lib.cuckoo.common.abstracts import Signature
+from cuckoo.misc import cwd
+from urlparse import urlsplit
 
 class ProcMemDumpURLs(Signature):
     name = "memdump_urls"

--- a/modules/signatures/windows/memdump_urls.py
+++ b/modules/signatures/windows/memdump_urls.py
@@ -1,6 +1,9 @@
 # Copyright (C) 2010-2015 Cuckoo Foundation.
 # This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
 # See the file 'docs/LICENSE' for copying permission.
+from cuckoo.misc import cwd
+import os
+from urlparse import urlsplit
 
 try:
     import re2 as re
@@ -17,10 +20,26 @@ class ProcMemDumpURLs(Signature):
     authors = ["Cuckoo Technologies"]
     minimum = "2.0"
 
+    whitelist_file = cwd("whitelist", "domain.txt")
+    whitelist = open(whitelist_file, "r")
+
+
     def on_complete(self):
         for procmem in self.get_results("procmemory", []):
             for url in procmem.get("urls", []):
-                self.mark_ioc("url", url)
+                #Extract top level domain from Procmem results
+                parts = urlsplit(url)
+                if parts[1]:
+                    url = parts[1]
+                else:
+                    pass
+                is_whitelisted = False
+                for white in ProcMemDumpURLs.whitelist:
+                    if re.match(white, url, re.IGNORECASE):
+                        is_whitelisted = True
+                        break
+                if not is_whitelisted:
+                    self.mark_ioc("url", url)
 
         return self.has_marks()
 
@@ -60,7 +79,6 @@ class ProcMemDumpTorURLs(Signature):
             ".vivavtpaymaster.com",
             ".fraspartypay.com",
         ]
-
         for procmem in self.get_results("procmemory", []):
             for url in procmem.get("urls", []):
                 for indicator in indicators:


### PR DESCRIPTION
I added a whitelist variable utlizing the urlsplit library which is already installed.  This allows users an easy way to whitelist domains using the domain.txt file located in cwd/whitelist/.  This signature caused misleading "hits "that require the analyst to spend large amounts of time sifting through legitimate URL's in order to find a malicious URL. This change allows users to add any whitelisted entries into the domain.txt file as an easy way to trim down the "noise". 

Original Alert:
![Malicious URL finding - Adobe](https://user-images.githubusercontent.com/26675035/62417334-ea6e1a80-b61a-11e9-9a59-be5e5b3a8c82.PNG)

Added armmf.adobe.com to cwd/whitelist/domain.txt with nano:
![domain_txt entries](https://user-images.githubusercontent.com/26675035/62417347-33be6a00-b61b-11e9-8c70-f28d0b69394a.PNG)

New Alert:
![Malicious URL finding - Adobe_after adding_armmf_adobe_com](https://user-images.githubusercontent.com/26675035/62417355-518bcf00-b61b-11e9-9672-02cb9ae9181f.PNG)

Thank you.