### PR TITLE
add signature network/check_against_urlhaus.py

### DIFF
--- a/modules/signatures/network/check_against_urlhaus.py
+++ b/modules/signatures/network/check_against_urlhaus.py
@@ -1,0 +1,25 @@
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# This signature was contributed by Clevero (Marcel Caspar) - https://sittig.de
+# See the file 'docs/LICENSE' for copying permission.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class URLhaus(Signature):
+    name = "check_domains_against_URLhaus"
+    description = "Tries to contact a domain that was listed at URLhaus"
+    severity = 5
+    categories = ["dns"]
+    authors = ["Marcel Caspar, Sittig Technologies GmbH"]
+    minimum = "2.0"
+   
+    def on_complete(self):
+        filepath = '/var/lib/peekaboo/urlhaus.txt'
+        with open(filepath) as fp:
+            line = fp.readline()
+            while line:
+                for match in self.check_domain(pattern=line.strip(), regex=True, all=True):
+                    self.mark_ioc("domain", line.strip())
+                    self.severity += 1
+                line = fp.readline()
+
+        return self.has_marks()


### PR DESCRIPTION
URLhaus provides a list of URLs that are serving malware.
https://urlhaus.abuse.ch/

It would be cool if cuckoo could raise a signature when one of those domains is queried. 

I hope this belongs to here since there is an external file needed and the path for this file needs to be changed in order to work. But I wanted to share it, so if anything needs to be changed I would be glad to change that.

The file can be downloaded with a cronjob every 5 minutes:

```bash
#!/bin/bash

wget https://urlhaus.abuse.ch/downloads/text/ -O /tmp/urlhaus.raw.txt

# remove http:// and https://
cat /tmp/urlhaus.raw.txt | sed -e 's|^[^/]*//||' -e 's|/.*$||' >> /tmp/urlhaus.plain.txt
rm /tmp/urlhaus.raw.txt

# remove dupicate domains
sort -u /tmp/urlhaus.plain.txt > /var/lib/peekaboo/urlhaus.txt
rm /tmp/urlhaus.plain.txt```