### PR TITLE
Fix antivm_bochs_keys signature name, fixes #448

### DIFF
--- a/modules/signatures/windows/antivm_bochs_keys.py
+++ b/modules/signatures/windows/antivm_bochs_keys.py
@@ -16,7 +16,7 @@
 from lib.cuckoo.common.abstracts import Signature
 
 class BochsDetectKeys(Signature):
-    name = "antivm_xen_keys"
+    name = "antivm_bochs_keys"
     description = "Detects Bochs through the presence of a registry key"
     severity = 3
     categories = ["anti-vm"]


### PR DESCRIPTION
The signature in `antivm_bochs_keys.py` is erroneously named `antivm_xen_keys`, which conflicts with the signature name in the `antivm_xen_keys.py` file.

This changes the Bochs signature to be named `antivm_bochs_keys`.

This fixes #448.