### PR TITLE
Add signature for reg.exe called from command shell

### DIFF
--- a/modules/signatures/windows/regexe_call_from_cmd.py
+++ b/modules/signatures/windows/regexe_call_from_cmd.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2016 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class RegCallfromCMD(Signature):
+
+    name = "reg_called_from_cmd"
+    description = "Reg.exe called from Command Shell"
+    severity = 3
+    categories = ["analytic"]
+    authors = ["ZW"]
+    minimum = "2.0"
+    reference = ["https://car.mitre.org/analytics/CAR-2013-03-001/"]
+    ttp = [""]
+
+    def on_complete(self):
+      
+      for process in self.get_results("behavior", {}).get("processtree", []):
+            stack = [process]     
+            traversed_path = []
+            
+            while stack:
+                process_visit = stack.pop()
+                
+                if process_visit["process_name"] == "reg.exe":
+                    for visited_process_find_parent in traversed_path:
+                        if process_visit["ppid"] == visited_process_find_parent["pid"] and visited_process_find_parent["process_name"] == "cmd.exe":
+                            for visited_process_find_GP in traversed_path:
+                                if visited_process_find_parent["ppid"] == visited_process_find_GP["pid"] and visited_process_find_GP["process_name"] != "explorer.exe":
+                                    self.mark(marked_process = process)
+                                   
+                                    return self.has_marks()
+                                                
+                traversed_path.append(process_visit)
+                stack.extend(process_visit['children']) 
+                
+
+      


### PR DESCRIPTION
I have added a new signature for Windows, this signature is based on https://car.mitre.org/analytics/CAR-2013-03-001/ which is an Analytic, it will be triggered when the built-in utility reg.exe is called from the command shell. According to CAR, I completed a signature code which can traverse the processtree by DFS to capture the reg.exe call from command shell event. 

I have verified this signature by the following method. First, I created a Windows application that adds a registry key by calling reg.exe from the cmd.exe and downloaded Sysmon to record its event log. 
Secondly, by checking the event log manually, I confirmed that my windows application can trigger the analytic CAR-2013-03-001. After getting the cuckoo report of this application, I found that the processtree in the report indicates this analytic should have been triggered during the execution of the application. 
I also tested my signature on the malware sample(MD5:b5d77d9e5a93848aaf59cd6115e54732)which contains the behavior of query the registry.  I submit this malware sample again, the cuckoo new recorded report shows that my signature can capture this event correctly.
![擷取](https://user-images.githubusercontent.com/64392464/80571130-a0da2100-8a2e-11ea-9953-44232deb09fc.PNG)
