### PR TITLE
Adding signature to detect API hammering technique

### DIFF
--- a/modules/signatures/windows/antisandbox_api_hammering.py
+++ b/modules/signatures/windows/antisandbox_api_hammering.py
@@ -1,5 +1,3 @@
-# Copyright (C) 2016 Brad Spengler, Updated 2016 for Cuckoo 2.0
-#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/modules/signatures/windows/antisandbox_api_hammering.py
+++ b/modules/signatures/windows/antisandbox_api_hammering.py
@@ -27,8 +27,8 @@ class ApiHammering(Signature):
             process_apistats = apistats[pid]
             for api_call in process_apistats:
                 process_api_call_count = process_apistats[api_call]
-                if process_api_call_count > 100000:
-                    description = "%s was called %d times" % (api_call, process_api_call_count)
-                    self.mark_ioc("call", api_call, description=description)
+                if process_api_call_count > 10000:
+                    description = "Process %s made the call %s %d times" % (pid, api_call, process_api_call_count)
+                    self.mark(description=description)
         return self.has_marks()
 

--- a/modules/signatures/windows/antisandbox_api_hammering.py
+++ b/modules/signatures/windows/antisandbox_api_hammering.py
@@ -28,7 +28,7 @@ class ApiHammering(Signature):
             for api_call in process_apistats:
                 process_api_call_count = process_apistats[api_call]
                 if process_api_call_count > 100000:
-                    description = "%s was called %d" % (api_call, process_api_call_count)
+                    description = "%s was called %d times" % (api_call, process_api_call_count)
                     self.mark_ioc("call", api_call, description=description)
         return self.has_marks()
 

--- a/modules/signatures/windows/antisandbox_api_hammering.py
+++ b/modules/signatures/windows/antisandbox_api_hammering.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2016 Brad Spengler, Updated 2016 for Cuckoo 2.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ApiHammering(Signature):
+    name = "api_hammering"
+    description = "Makes an unusually high volume of API calls in the attempt to crash the sandbox."
+    severity = 4
+    categories = ["anti-sandbox"]
+    minimum = "2.0"
+    ttp = ["T1106", "T1497"]
+
+    def on_complete(self):
+        apistats = self.get_results("behavior", {}).get("apistats", {})
+        for pid in apistats:
+            process_apistats = apistats[pid]
+            for api_call in process_apistats:
+                process_api_call_count = process_apistats[api_call]
+                if process_api_call_count > 100000:
+                    self.mark_ioc("call", api_call, description="%s was called %d" % (api_call, process_api_call_count))
+        return self.has_marks()
+

--- a/modules/signatures/windows/antisandbox_api_hammering.py
+++ b/modules/signatures/windows/antisandbox_api_hammering.py
@@ -15,8 +15,8 @@ from lib.cuckoo.common.abstracts import Signature
 
 class ApiHammering(Signature):
     name = "api_hammering"
-    description = "Makes an unusually high volume of API calls in the attempt to crash the sandbox."
-    severity = 4
+    description = "Makes an unusually high volume of API calls, possibly in the attempt to crash the sandbox."
+    severity = 1
     categories = ["anti-sandbox"]
     minimum = "2.0"
     ttp = ["T1106", "T1497"]

--- a/modules/signatures/windows/antisandbox_api_hammering.py
+++ b/modules/signatures/windows/antisandbox_api_hammering.py
@@ -28,6 +28,7 @@ class ApiHammering(Signature):
             for api_call in process_apistats:
                 process_api_call_count = process_apistats[api_call]
                 if process_api_call_count > 100000:
-                    self.mark_ioc("call", api_call, description="%s was called %d" % (api_call, process_api_call_count))
+                    description = "%s was called %d" % (api_call, process_api_call_count)
+                    self.mark_ioc("call", api_call, description=description)
         return self.has_marks()
 


### PR DESCRIPTION
Samples such as `9d4997249a633b7488270a550eafe4576362f7a9128eb20901669283f4746958` use an unusually high amount of native API calls in order to crash the sandbox. This signature is meant to hit on this technique, called API Hammering.