### PR TITLE
Adding processes to the antisandbox_sleep safelist

### DIFF
--- a/modules/signatures/windows/antisandbox_sleep.py
+++ b/modules/signatures/windows/antisandbox_sleep.py
@@ -34,6 +34,7 @@ class AntiSandboxSleep(Signature):
         "excel.exe",
         "splwow64.exe",
         "powershell.exe",
+        "outlook.exe",
     ]
 
     def init(self):

--- a/modules/signatures/windows/antisandbox_sleep.py
+++ b/modules/signatures/windows/antisandbox_sleep.py
@@ -32,6 +32,7 @@ class AntiSandboxSleep(Signature):
         "acrord32.exe",
         "winword.exe",
         "excel.exe",
+        "splwow64.exe",
     ]
 
     def init(self):

--- a/modules/signatures/windows/antisandbox_sleep.py
+++ b/modules/signatures/windows/antisandbox_sleep.py
@@ -33,6 +33,7 @@ class AntiSandboxSleep(Signature):
         "winword.exe",
         "excel.exe",
         "splwow64.exe",
+        "powershell.exe",
     ]
 
     def init(self):


### PR DESCRIPTION
Through analyzing thousands of benign and malicious submissions, this process is created by all office files and hits a nearly 100% false-positive rate unless it is safelisted.

Regarding Powershell, out of all the samples analyzed approximately 10% of samples raise this signature and 100% of these samples that raise this signature are benign.

Regarding Outlook, out of all the samples analyzed approximately, 100% of benign samples raised this signature.