### PR TITLE
Safelisting powershell in antivm_disksize

### DIFF
--- a/modules/signatures/windows/antivm_disksize.py
+++ b/modules/signatures/windows/antivm_disksize.py
@@ -44,7 +44,8 @@ class AntiVMDiskSize(Signature):
         "excel.exe",
         "powerpnt.exe",
         "outlook.exe",
-        "mspub.exe"
+        "mspub.exe",
+        "powershell.exe",
     ]
 
     def on_call(self, call, process):


### PR DESCRIPTION
After submitting thousands of PowerShell files, I have determined that this signature is raised an overwhelming majority of the time for benign files. Therefore I suggest that we safelist `powershell.exe`.