### PR TITLE
Removing false positives created by temporary Office files

### DIFF
--- a/modules/signatures/windows/creates_doc.py
+++ b/modules/signatures/windows/creates_doc.py
@@ -31,7 +31,7 @@ class CreatesDocument(Signature):
             temp_truncated_filename = filename[-11:]
 
         for filepath in self.check_file(pattern=self.pattern, actions=["file_written"], regex=True, all=True):
-            if filename in filepath or ("~$" in filepath and (temp_truncated_filename and temp_truncated_filename in filepath)):
+            if filename in filepath or ("~$" in filepath and temp_truncated_filename and temp_truncated_filename in filepath):
                 continue
             self.mark_ioc("file", filepath)
 

--- a/modules/signatures/windows/creates_hidden_file.py
+++ b/modules/signatures/windows/creates_hidden_file.py
@@ -14,13 +14,32 @@ class CreatesHiddenFile(Signature):
     minimum = "2.0"
     ttp = ["T1158"]
     filter_apinames = "NtCreateFile", "SetFileAttributesW"
+    safelist = ["winword.exe"]
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.hidden_attrs = [2, 4]
         self.open_dispositions = [1, 3]
+        self.filename = None
+        self.temp_truncated_filename = None
+        if self.get_results("target", {}).get("category") == "file":
+            f = self.get_results("target", {}).get("file", {})
+            self.filename = f.get("name")
+            if len(self.filename) > 12:
+                self.temp_truncated_filename = self.filename[-11:]
 
     def on_call(self, call, process):
+        if process["process_name"].lower() in self.safelist:
+            # Microsoft Word creates hidden temporary files to be used as backups.
+            # These are false positives for this signature.
+            # Their naming follows the convention \path\to\file\~$(substring of filename if length of filename > 12|filename)
+            filepath = call["arguments"]["filepath"]
+            if "~$" in filepath and \
+                    ((self.temp_truncated_filename and self.temp_truncated_filename in filepath) or
+                     (self.filename and self.filename in filepath)):
+                # Definitely an FP
+                return
+
         attr = call["arguments"]["file_attributes"]
         if attr in self.hidden_attrs:
              if call["api"] == "NtCreateFile":


### PR DESCRIPTION
`creates_hidden_file` and `creates_doc signatures` both are raised falsely when a temporary backup Office file is created after an Office file is opened. This PR refines these signatures to avoid that.