### PR TITLE
Added safelist for the exploit_heapspray signature

### DIFF
--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -14,6 +14,7 @@ class ExploitHeapspray(Signature):
     references = ["https://www.corelan.be/index.php/2011/12/31/exploit-writing-tutorial-part-11-heap-spraying-demystified/"]
 
     filter_apinames = "NtAllocateVirtualMemory",
+    process_safelist = ["excel.exe"]
 
     def init(self):
         self.mem = {}
@@ -35,6 +36,8 @@ class ExploitHeapspray(Signature):
 
     def on_call(self, call, process):
         pname = process["process_name"]
+        if pname.lower() in self.process_safelist:
+            return
         protection = call["arguments"]["protection"]
         alloc_type = call["arguments"]["allocation_type"]
         region_size = call["arguments"]["region_size"]

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -20,9 +20,17 @@ class ExploitHeapspray(Signature):
         self.prot = {}
         self.heaptotals = dict()
         self.ignore = False
+        file_type_safelist = [
+            "PE32 executable",
+            "PE32+ executable",
+            # False Positives are raised for benign Microsoft Excel and Word files
+            "Microsoft Excel 2007+",
+            "Zip archive data, at least v1.0 to extract",
+            "Microsoft Word 2007+",
+        ]
         if self.get_results("target", {}).get("category") == "file":
             f = self.get_results("target", {}).get("file", {})
-            if "PE32 executable" in  f.get("type", "") or "PE32+ executable" in f.get("type", ""):
+            if any(type_string in f.get("type", "") for type_string in file_type_safelist):
                 self.ignore = True
 
     def on_call(self, call, process):


### PR DESCRIPTION
Based on thousands of samples submitted and analyzed, I found that benign Word and Excel files were raising this signature. Therefore converted signature to use a safelist and added Word and Excel file types.