### PR TITLE
Adding process safelist for stack pivot

### DIFF
--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -120,9 +120,10 @@ class StackPivot(Signature):
         if "stack_pivoted" in call["arguments"]:
             if call["arguments"]["stack_pivoted"] == 1 and not self.ignore:
                 pname = process["process_name"]
-                if pname.lower() not in self.process_safelist and pname not in self.pname:
+                if pname not in self.pname:
                     self.pname.append(pname)
-                self.mark_call()
+                if pname.lower() not in self.process_safelist:
+                    self.mark_call()
 
     def on_complete(self):
         if len(self.pname) == 1:

--- a/modules/signatures/windows/exploitation.py
+++ b/modules/signatures/windows/exploitation.py
@@ -105,6 +105,7 @@ class StackPivot(Signature):
     minimum = "2.0"
 
     filter_apinames = critical_apinames
+    process_safelist = ["winword.exe"]
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
@@ -119,7 +120,7 @@ class StackPivot(Signature):
         if "stack_pivoted" in call["arguments"]:
             if call["arguments"]["stack_pivoted"] == 1 and not self.ignore:
                 pname = process["process_name"]
-                if pname not in self.pname:
+                if pname.lower() not in self.process_safelist and pname not in self.pname:
                     self.pname.append(pname)
                 self.mark_call()
 


### PR DESCRIPTION
Winword created too many false positives to be considered worth including in the signature