### PR TITLE
Safelisting powershell in signatures due to FPs

### DIFF
--- a/modules/signatures/windows/antisandbox_idletime.py
+++ b/modules/signatures/windows/antisandbox_idletime.py
@@ -14,8 +14,11 @@ class AntiSandboxIdleTime(Signature):
     ttp = ["T1082"]
 
     filter_apinames = "NtQuerySystemInformation",
+    process_safelist = ["powershell.exe"]
 
-    def on_call(self, call, processs):
+    def on_call(self, call, process):
+        if process["process_name"] in self.process_safelist:
+            return
         if call["flags"]["information_class"] == \
                 "SystemProcessorPerformanceInformation":
             self.mark_call()

--- a/modules/signatures/windows/crypto_apis.py
+++ b/modules/signatures/windows/crypto_apis.py
@@ -24,8 +24,11 @@ class CryptGenKey(Signature):
     minimum = "2.0"
 
     filter_apinames = "CryptGenKey", "CryptExportKey",
+    process_safelist = ["powershell.exe"]
 
     def on_call(self, call, process):
+        if process["process_name"] in self.process_safelist:
+            return
         self.mark_call()
 
     def on_complete(self):

--- a/modules/signatures/windows/powershell.py
+++ b/modules/signatures/windows/powershell.py
@@ -13,9 +13,18 @@ class SuspiciousPowershell(Signature):
     categories = ["script", "dropper", "downloader", "packer"]
     authors = ["Kevin Ross", "Cuckoo Technologies", "FDD"]
     minimum = "2.0"
+    ps1_package_cmd = "-NoProfile -ExecutionPolicy unrestricted -File"
 
     def on_complete(self):
         for cmdline in self.get_command_lines():
+            # We can afford to try to match the substring in a case-sensitive way since this is how Cuckoo's
+            # PowerShell package runs PowerShell files.
+            if self.ps1_package_cmd in cmdline:
+                f = self.get_results("target", {}).get("file", {})
+                filename = f.get("name")
+                if filename and filename in cmdline:
+                    # False Positive found
+                    continue
             lower = cmdline.lower()
 
             if "powershell" not in lower:

--- a/modules/signatures/windows/suspicious_process.py
+++ b/modules/signatures/windows/suspicious_process.py
@@ -16,10 +16,17 @@ class CreatesSuspiciousProcess(Signature):
         "svchost", "powershell", "regsvr32", "bcdedit", "mshta", "schtasks",
         "wmic", "cmd.exe",
     ]
+    ps1_package_cmd = "-NoProfile -ExecutionPolicy unrestricted -File"
 
     def on_complete(self):
         for cmdline in self.get_command_lines():
             for process in self.processes:
+                if process == "powershell" and self.ps1_package_cmd in cmdline:
+                    f = self.get_results("target", {}).get("file", {})
+                    filename = f.get("name")
+                    if filename and filename in cmdline:
+                        # False Positive found
+                        continue
                 if process in cmdline.lower():
                     self.mark_ioc("cmdline", cmdline)
                     break


### PR DESCRIPTION
Pretty crazy, if you run a PowerShell file, regardless of what it does, these signatures will be always be raised. This PR is aimed at fixing that.