### PR TITLE
Handle if uri == host

### DIFF
--- a/modules/signatures/network/network_cnc_http.py
+++ b/modules/signatures/network/network_cnc_http.py
@@ -95,7 +95,10 @@ class NetworkCnCHTTP(Signature):
                 reasons.append("Connection to IP address")
 
             if len(reasons) > 0:
-                request = "%s %s://%s%s" % (http["method"], http["protocol"], http["host"], http["uri"])
+                if http["host"] not in http["uri"]:
+                    request = "%s %s://%s%s" % (http["method"], http["protocol"], http["host"], http["uri"])
+                else:
+                    request = "%s %s://%s" % (http["method"], http["protocol"], http["host"])
                 if request not in suspectrequests:
                     features = ', '.join(reasons)
                     suspectrequests.append(request)

--- a/modules/signatures/network/network_cnc_http.py
+++ b/modules/signatures/network/network_cnc_http.py
@@ -95,7 +95,7 @@ class NetworkCnCHTTP(Signature):
                 reasons.append("Connection to IP address")
 
             if len(reasons) > 0:
-                if http["host"] not in http["uri"]:
+                if not http["uri"].startswith(http["host"]):
                     request = "%s %s://%s%s" % (http["method"], http["protocol"], http["host"], http["uri"])
                 else:
                     request = "%s %s://%s" % (http["method"], http["protocol"], http["host"])


### PR DESCRIPTION
This signature was creating URIs where the domain was duplicated, due "uri" and "host" being equal in some network calls found in "http_ex"